### PR TITLE
refactor(shop): replace native <textarea> with shared <Textarea /> component

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/content.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/content.tsx
@@ -21,6 +21,7 @@ import {
   AlertDialogTitle,
   BackgroundImage,
   Quantity,
+  Textarea,
 } from '@/ui/components';
 import {useQuantity, useToast} from '@/ui/hooks';
 import {useCart} from '@/app/[tenant]/[workspace]/cart-context';
@@ -130,7 +131,7 @@ function CartItem({item, disabled, handleRemove, displayPrices}: any) {
           {product.allowCustomNote && (
             <div>
               <Label>{i18n.t('Note')}</Label>
-              <textarea
+              <Textarea
                 className="border rounded-lg"
                 value={note}
                 onChange={handleChangeNote}

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-view/product-view.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-view/product-view.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Breadcrumbs,
   NavbarCategoryMenu,
+  Textarea,
 } from '@/ui/components';
 import {useQuantity, useToast} from '@/ui/hooks';
 import {i18n} from '@/locale';
@@ -165,7 +166,7 @@ export function ProductView({
             {Boolean(cartQuantity) && product.allowCustomNote && (
               <div>
                 <Label>{i18n.t('Note')}</Label>
-                <textarea
+                <Textarea
                   className="border rounded-lg"
                   value={note}
                   onChange={handleChangeNote}

--- a/changelogs/unreleased/98638.json
+++ b/changelogs/unreleased/98638.json
@@ -1,0 +1,5 @@
+{
+  "title": "Replace native <textarea> with cire <Textarea/> component",
+  "type": "change",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
**What’s changed**
Replaced all instances of the native HTML <textarea> with the application's shared <Textarea /> component across the app.

**Why it’s needed**
Using the shared <Textarea /> ensures:
- Consistent styling and behavior across the application
- Better maintainability and reusability
- Alignment with the design system and UI standards

**Checklist**
-  Replaced native <textarea> in relevant forms/components
-  Verified visual and functional parity with previous inputs- 
-  Confirmed no styling or layout regressions