### PR TITLE
refactor(shop): replace router.push with Next.js Link 

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/featured-categories/featured-categories.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/featured-categories/featured-categories.tsx
@@ -10,7 +10,8 @@ import {useCart} from '@/app/[tenant]/[workspace]/cart-context';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
 import type {Product, Category, ComputedProduct} from '@/types';
 
-import {ProductCard} from '../product-card';
+// ---- LOCAL IMPORTS ---- //
+import {Link, ProductCard} from '@/subapps/shop/common/ui/components';
 
 export function FeaturedCategories({categories, workspace}: any) {
   const router = useRouter();
@@ -34,27 +35,17 @@ export function FeaturedCategories({categories, workspace}: any) {
     });
   };
 
-  const handleProductClick = (category: Category) => (product: Product) => {
-    router.push(
-      `${workspaceURI}/shop/category/${category.slug}/product/${product.slug}`,
-    );
-  };
-
-  const handleCategoryClick = ({category}: {category: Category}) => {
-    router.push(`${workspaceURI}/shop/category/${category.slug}`);
-  };
-
   return categories?.map((category: any) =>
     category?.products?.length ? (
       <Fragment key={category.id}>
         <div className="flex justify-between items-center">
           <h3 className="text-xl leading-7 font-medium">{category.name}</h3>
-          <div
-            className="flex gap-2 px-3 py-4 cursor-pointer"
-            onClick={() => handleCategoryClick({category})}>
-            <span className="leading-6 text-sm">{i18n.t('See All')}</span>
-            <MdEast className="w-6 h-6" />
-          </div>
+          <Link href={`${workspaceURI}/shop/category/${category.slug}`}>
+            <div className="flex gap-2 px-3 py-4 cursor-pointer">
+              <span className="leading-6 text-sm">{i18n.t('See All')}</span>
+              <MdEast className="w-6 h-6" />
+            </div>
+          </Link>
         </div>
         <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
           {category.products.map((computedProduct: ComputedProduct) => {
@@ -69,8 +60,8 @@ export function FeaturedCategories({categories, workspace}: any) {
                 product={computedProduct}
                 quantity={quantity}
                 onAdd={handleAddProduct}
+                category={category}
                 displayPrices={workspace?.config?.displayPrices}
-                onClick={handleProductClick(category)}
               />
             );
           })}

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/index.ts
@@ -32,3 +32,4 @@ export {
   AddressSelectionSkeleton,
   CheckoutSkeleton,
 } from './skeleton';
+export {Link} from './link';

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/link/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/link/index.ts
@@ -1,0 +1,1 @@
+export * from './link';

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/link/link.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/link/link.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import NextLink from 'next/link';
+
+type Props = {
+  href: string;
+  children: React.ReactNode;
+  className?: string;
+  prefetch?: boolean;
+};
+
+export function Link({
+  href,
+  children,
+  className = '',
+  prefetch = false,
+  ...rest
+}: Props) {
+  return (
+    <NextLink href={href} prefetch={prefetch} className={className} {...rest}>
+      {children}
+    </NextLink>
+  );
+}
+
+export default Link;

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-card/product-card.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-card/product-card.tsx
@@ -10,25 +10,29 @@ import {i18n} from '@/locale';
 import {cn} from '@/utils/css';
 import {useToast} from '@/ui/hooks';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
-import type {ComputedProduct, ID, Product} from '@/types';
+import type {Category, ComputedProduct, ID, Product} from '@/types';
+
+// ---- LOCAL IMPORTS ---- //
+import {Link} from '@/subapps/shop/common/ui/components';
 
 export type ProductCardProps = {
   product: ComputedProduct;
   quantity?: string | number;
   onAdd: (product: ComputedProduct) => Promise<void>;
-  onClick: (product: Product) => void;
   displayPrices?: boolean;
+  category: Category;
 };
+
 export function ProductCard({
   product: computedProduct,
   quantity = 0,
   onAdd,
-  onClick,
+  category,
   displayPrices,
 }: ProductCardProps) {
   const {product, price, errorMessage} = computedProduct;
   const {displayTwoPrices, displayPrimary, displaySecondary} = price;
-  const {tenant} = useWorkspace();
+  const {tenant, workspaceURI} = useWorkspace();
 
   const {outOfStockConfig} = product;
   const isOutOfStock = outOfStockConfig?.outOfStock;
@@ -39,10 +43,6 @@ export function ProductCard({
     onAdd(computedProduct);
   };
 
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    onClick && onClick(product);
-  };
-
   return (
     <div
       className={cn(
@@ -51,7 +51,8 @@ export function ProductCard({
           'min-h-[25.625rem]': displayPrices,
         },
       )}>
-      <div onClick={handleClick}>
+      <Link
+        href={`${workspaceURI}/shop/category/${category.slug}/product/${product.slug}`}>
         <BackgroundImage
           className="rounded-t-lg bg-cover relative h-[14.5rem]"
           src={getProductImageURL(
@@ -79,7 +80,7 @@ export function ProductCard({
             </>
           )}
         </div>
-      </div>
+      </Link>
       <div className="flex items-start justify-between p-6 pt-0">
         <div>
           {showMessage && isOutOfStock && (

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-list-item/product-list-item.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-list-item/product-list-item.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React from 'react';
 import {MdAddShoppingCart} from 'react-icons/md';
 
@@ -9,26 +10,29 @@ import {getProductImageURL} from '@/utils/files';
 import {useResponsive} from '@/ui/hooks';
 import {i18n} from '@/locale';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
-import type {ComputedProduct, ID, Product} from '@/types';
+import type {Category, ComputedProduct, ID, Product} from '@/types';
+
+// ---- LOCAL IMPORTS ---- //
+import {Link} from '@/subapps/shop/common/ui/components';
 
 export type ProductListItemProps = {
   product: ComputedProduct;
   quantity?: string | number;
   onAdd: (product: ComputedProduct) => Promise<void>;
-  onClick: (product: Product) => void;
   displayPrices?: boolean;
+  category: Category;
 };
 
 export function ProductListItem({
   product: computedProduct,
   quantity = 0,
   onAdd,
-  onClick,
   displayPrices,
+  category,
 }: ProductListItemProps) {
   const {product, price, errorMessage} = computedProduct;
   const {displayTwoPrices, displayPrimary, displaySecondary} = price;
-  const {tenant} = useWorkspace();
+  const {tenant, workspaceURI} = useWorkspace();
 
   const {outOfStockConfig} = product;
   const isOutOfStock = outOfStockConfig?.outOfStock;
@@ -36,68 +40,69 @@ export function ProductListItem({
   const canBuy = outOfStockConfig?.canBuy;
 
   const handleAdd = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     onAdd(computedProduct);
-  };
-
-  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    onClick && onClick(product);
   };
 
   const res: any = useResponsive();
   const large = ['md', 'lg', 'xl', 'xxl'].some(x => res[x]);
 
   return (
-    <div className="cursor-pointer rounded-2xl grid grid-cols-1 md:grid-cols-[14.875rem_1fr] gap-6 w-full bg-card text-card-foreground">
-      <BackgroundImage
-        className="rounded-l-lg relative bg-cover md:w-[14.875rem] w-[5rem] md:h-[14.6875rem] h-[5rem]"
-        src={getProductImageURL(product.images?.[0] as ID, tenant)}>
-        {Boolean(quantity) && (
-          <div className="border shadow-lg absolute bottom-4 right-4 bg-card p-1 md:p-4 rounded-full flex items-center justify-center w-[1.875rem] md:w-[3.75rem] h-[1.875rem] md:h-[3.75rem]">
-            <p className="mb-0 text-sm md:text-xl">{quantity}</p>
-          </div>
-        )}
-      </BackgroundImage>
-      <div className="p-6 pl-6 md:pl-0 flex flex-col justify-between gap-4">
-        <div onClick={handleClick}>
-          <>
-            <div className="flex-col md:flex-row flex justify-between mb-6">
-              <div>
-                <p className="font-medium mb-2 md:mb-0">
-                  {i18n.tattr(product.name)}
-                </p>
-                {showMessage && isOutOfStock && (
-                  <p className="text-xs font-semibold mt-0 mb-0 text-destructive">
-                    {i18n.t('Out of stock')}
-                  </p>
-                )}
-                {errorMessage && (
-                  <p className="text-xs font-semibold mt-0 mb-0 text-destructive">
-                    {i18n.t('Price may be incorrect')}
-                  </p>
-                )}
-              </div>
-              <div className="shrink-0 text-right">
-                {displayPrices && (
-                  <>
-                    <h4 className="text-xl font-semibold mb-0">
-                      {displayPrimary}
-                    </h4>
-                    {displayTwoPrices && (
-                      <p className="text-sm font-medium mt-2 mb-0">
-                        {displaySecondary}
-                      </p>
-                    )}
-                  </>
-                )}
-              </div>
+    <div className="rounded-2xl grid grid-cols-1 md:grid-cols-[14.875rem_1fr] gap-6 w-full bg-card text-card-foreground">
+      <Link
+        href={`${workspaceURI}/shop/category/${category.slug}/product/${product.slug}`}
+        className="cursor-pointer">
+        <BackgroundImage
+          className="rounded-l-lg relative bg-cover md:w-[14.875rem] w-[5rem] md:h-[14.6875rem] h-[5rem]"
+          src={getProductImageURL(product.images?.[0] as ID, tenant)}>
+          {Boolean(quantity) && (
+            <div className="border shadow-lg absolute bottom-4 right-4 bg-card p-1 md:p-4 rounded-full flex items-center justify-center w-[1.875rem] md:w-[3.75rem] h-[1.875rem] md:h-[3.75rem]">
+              <p className="mb-0 text-sm md:text-xl">{quantity}</p>
             </div>
-            <p
-              className={cn('text-xs mb-4 md:mb-0', {'line-clamp-3': !large})}
-              dangerouslySetInnerHTML={{
-                __html: product.description || '',
-              }}></p>
-          </>
-        </div>
+          )}
+        </BackgroundImage>
+      </Link>
+      <div className="p-6 pl-6 md:pl-0 flex flex-col justify-between gap-4">
+        <Link
+          href={`${workspaceURI}/shop/category/${category.slug}/product/${product.slug}`}
+          className="cursor-pointer">
+          <div className="flex-col md:flex-row flex justify-between mb-6">
+            <div>
+              <p className="font-medium mb-2 md:mb-0">
+                {i18n.tattr(product.name)}
+              </p>
+              {showMessage && isOutOfStock && (
+                <p className="text-xs font-semibold mt-0 mb-0 text-destructive">
+                  {i18n.t('Out of stock')}
+                </p>
+              )}
+              {errorMessage && (
+                <p className="text-xs font-semibold mt-0 mb-0 text-destructive">
+                  {i18n.t('Price may be incorrect')}
+                </p>
+              )}
+            </div>
+            <div className="shrink-0 text-right">
+              {displayPrices && (
+                <>
+                  <h4 className="text-xl font-semibold mb-0">
+                    {displayPrimary}
+                  </h4>
+                  {displayTwoPrices && (
+                    <p className="text-sm font-medium mt-2 mb-0">
+                      {displaySecondary}
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          <p
+            className="text-xs mb-4 md:mb-0 line-clamp-3"
+            dangerouslySetInnerHTML={{
+              __html: product.description || '',
+            }}></p>
+        </Link>
         {canBuy && (
           <div className="flex justify-end">
             <Button

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-list/product-list.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-list/product-list.tsx
@@ -241,7 +241,7 @@ export function ProductList({
                     quantity={quantity}
                     onAdd={handleAdd}
                     displayPrices={workspace?.config?.displayPrices}
-                    onClick={handleProductClick}
+                    category={category}
                   />
                 );
               })

--- a/changelogs/unreleased/98637.json
+++ b/changelogs/unreleased/98637.json
@@ -1,0 +1,5 @@
+{
+  "title": "Refactor routing by replacing router.push with Next.js <Link> component",
+  "type": "change",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
This PR refactors routing in the Shop app by replacing instances of router.push with the built-in Next.js <Link> component where appropriate. This change is aimed at improving routing efficiency, accessibility, and alignment with Next.js best practices.

**Benefits**
-  Improved client-side routing performance
- Enhanced semantic HTML for accessibility and SEO
- Better alignment with Next.js navigation standards

**Affected Pages/Components**
- Shop homepage
- Category Page
- Featured Categories component
- Product Card View component
- Product List Item component

**Checklist**
-  Replaced router.push where navigation can be handled by <Link>
-  Verified navigation functionality remains consistent
