### PR TITLE
feat: add ZIP-based city fetching alongside country  (#100901)

### DIFF
--- a/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
@@ -29,9 +29,11 @@ import {getQuotationRecord} from '@/app/[tenant]/[workspace]/account/addresses/c
 export const fetchCities = async ({
   countryId,
   workspaceURL,
+  zip,
 }: {
   countryId: string | number;
   workspaceURL: string;
+  zip: string;
 }) => {
   if (!countryId) {
     return {
@@ -39,6 +41,12 @@ export const fetchCities = async ({
       message: await t('Country Id is required'),
     };
   }
+
+  if (!zip)
+    return {
+      error: true,
+      message: await t('Zip is required'),
+    };
 
   if (!workspaceURL) {
     return {
@@ -79,7 +87,7 @@ export const fetchCities = async ({
   }
 
   try {
-    const cities = await findCities({countryId: country.id, tenantId});
+    const cities = await findCities({countryId: country.id, zip, tenantId});
     return {
       success: true,
       data: clone(cities),

--- a/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import {useEffect} from 'react';
+import clsx from 'clsx';
+
 // ---- CORE IMPORTS ---- //
 import {i18n} from '@/locale';
 import {
@@ -17,10 +20,6 @@ import {
 import {City, Country} from '@/types';
 
 interface AddressInformationProps {
-  country: {
-    id: string | number;
-    name: string;
-  };
   countries: Country[];
   cities: City[];
   form: any;
@@ -30,8 +29,10 @@ export function AddressInformation({
   countries,
   cities = [],
   form,
-  country,
 }: AddressInformationProps) {
+  const countryId = form.watch('addressInformation.country.id');
+  const zipCode = form.watch('addressInformation.zip');
+
   const handleCountryChange = (selectedOption: {id: string; name: string}) => {
     form.setValue('addressInformation.country', selectedOption, {
       shouldValidate: true,
@@ -45,6 +46,12 @@ export function AddressInformation({
     });
     form.trigger('addressInformation.city.id');
   };
+
+  useEffect(() => {
+    if (countryId && zipCode) {
+      form.trigger('addressInformation.city.id');
+    }
+  }, [countryId, zipCode, form]);
 
   return (
     <div className="bg-white py-4 px-6 rounded-lg">
@@ -142,7 +149,7 @@ export function AddressInformation({
           <FormField
             control={form.control}
             name="addressInformation.city.id"
-            render={({field}) => (
+            render={({field, fieldState}) => (
               <FormItem className="md:col-span-2">
                 <FormControl>
                   <DropdownSelector
@@ -151,12 +158,12 @@ export function AddressInformation({
                     isRequired={true}
                     label={i18n.t('City')}
                     placeholder={i18n.t('Select city')}
-                    labelClassName="mb-0"
+                    labelClassName={clsx(
+                      'mb-0',
+                      fieldState?.error && 'text-destructive',
+                    )}
                     rootClassName="space-y-2"
-                    disabled={!country.id}
-                    hasError={
-                      !!form.formState.errors?.addressInformation?.city?.id
-                    }
+                    disabled={!countryId || !zipCode}
                     onValueChange={handleCityChange}
                   />
                 </FormControl>

--- a/changelogs/unreleased/100901.json
+++ b/changelogs/unreleased/100901.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add support to fetch cities based on ZIP code",
+  "type": "feature",
+  "description": "Enhanced the address selection functionality to allow fetching cities not only based on the selected country but also using the entered ZIP code. This ensures more accurate city suggestions and improves the user experience during address entry.",
+  "scope": ["users"]
+}

--- a/orm/address.ts
+++ b/orm/address.ts
@@ -427,11 +427,13 @@ export async function findCountry({
 export async function findCities({
   countryId,
   tenantId,
+  zip,
 }: {
   countryId: string | number;
   tenantId: Tenant['id'];
+  zip: string;
 }): Promise<City[]> {
-  if (!tenantId || !countryId) return [];
+  if (!tenantId || !countryId || !zip) return [];
 
   try {
     const client = await manager.getClient(tenantId);
@@ -439,6 +441,7 @@ export async function findCities({
     const cities = await client.aOSCity.find({
       where: {
         country: {id: countryId},
+        zip,
       },
     });
 


### PR DESCRIPTION
### What’s Added
- Enhanced city fetching: now supports fetching based on ZIP code in addition to country.

### Why
- To improve accuracy of city suggestions and enhance user experience when entering addresses.

### Notes
- City selection is now conditionally required only after both country and ZIP are provided.
- Dropdown is disabled until country and ZIP are filled.