### PR TITLE
feat: add support for partial invoice for pay-in-advance orders (#100907)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/content.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/content.tsx
@@ -27,6 +27,7 @@ import {i18n} from '@/locale';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
 import {type PortalWorkspace} from '@/types';
 import {formatNumber} from '@/locale/formatters';
+import {calculateAdvanceAmount} from '@/utils/payment';
 
 // ---- LOCAL IMPORTS ---- //
 import {findProduct} from '@/subapps/shop/common/actions/cart';
@@ -92,13 +93,26 @@ function Total({cart, shippingType, workspace}: any) {
     scale: {currency: currencyScale},
     currency: {symbol: currencySymbol},
   } = computeTotal({cart, workspace});
+
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
   const shipping = Number(
     scale(SHIPPING_TYPE_COST[shippingType], currencyScale),
   ) as number;
-  const totalWithShipping = formatNumber(Number(total) + Number(shipping), {
+
+  const totalAmount = Number(total) + Number(shipping);
+
+  const totalWithShipping = formatNumber(totalAmount, {
     currency: currencySymbol,
     scale: currencyScale,
     type: 'DECIMAL',
+  });
+
+  const advanceAmount = calculateAdvanceAmount({
+    amount: Number(total),
+    percentage: advancePaymentPercentage,
+    payInAdvance,
   });
 
   return (
@@ -130,6 +144,23 @@ function Total({cart, shippingType, workspace}: any) {
           <p className="text-xl font-semibold">{`${totalWithShipping} `}</p>
         </div>
       </div>
+      {payInAdvance && advanceAmount && (
+        <>
+          <Separator className="my-4" />
+          <div className="flex items-center justify-between">
+            <p className="font-medium">{i18n.t('Advance Amount Due')}:</p>
+            <div>
+              <p className="text-lg font-semibold">
+                {formatNumber(advanceAmount, {
+                  currency: currencySymbol,
+                  scale: currencyScale,
+                  type: 'DECIMAL',
+                })}
+              </p>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/changelogs/unreleased/100907.json
+++ b/changelogs/unreleased/100907.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add support for partial invoice for pay-in-advance orders",
+  "type": "feature",
+  "description": "Generates an invoice for the advance payment percentage when pay-in-advance is enabled.",
+  "scope": ["shop"]
+}

--- a/goovee/schema/AOSPortalAppConfig.json
+++ b/goovee/schema/AOSPortalAppConfig.json
@@ -350,6 +350,10 @@
     {
       "name": "isCompanyOrAddressRequired",
       "type": "Boolean"
+    },
+    {
+      "name": "advancePaymentPercentage",
+      "type": "Decimal"
     }
   ]
 }

--- a/orm/workspace.ts
+++ b/orm/workspace.ts
@@ -119,6 +119,8 @@ export const portalAppConfigFields: SelectOptions<AOSPortalAppConfig> = {
   contactName: true,
   contactPhone: true,
   isCompanyOrAddressRequired: true,
+  payInAdvance: true,
+  advancePaymentPercentage: true,
 };
 
 export async function findWorkspaceMembers({

--- a/types/index.ts
+++ b/types/index.ts
@@ -77,7 +77,6 @@ export interface PortalAppConfig extends Model {
   displayTwoPrices: string;
   mainPrice: string;
   eSignature: boolean;
-  payInAdvance: boolean;
   priceAfterLogin: string;
   requestQuotation: boolean;
   paymentOptionSet?: Array<{}>;
@@ -165,6 +164,8 @@ export interface PortalAppConfig extends Model {
   contactEmailAddress?: {address?: string};
   contactPhone?: string;
   isCompanyOrAddressRequired?: boolean;
+  payInAdvance?: boolean;
+  advancePaymentPercentage?: BigDecimal;
 }
 
 export interface PortalApp extends Model {

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -4,3 +4,22 @@ export const isPaymentOptionAvailable = (
   paymentOptions: any[] = [],
   type: PaymentOption,
 ) => paymentOptions.some((option: any) => option?.typeSelect === type);
+
+export function calculateAdvanceAmount({
+  amount,
+  percentage,
+  payInAdvance,
+}: {
+  amount: number;
+  percentage?: string | number;
+  payInAdvance?: boolean;
+}): number {
+  if (!payInAdvance || !percentage) return amount;
+
+  const amountNum = Number(amount);
+  const percent = Number(percentage ?? 0);
+
+  if (isNaN(percent) || percent <= 0) return amount;
+
+  return (amountNum * percent) / 100;
+}


### PR DESCRIPTION
### What’s Added
Partial payment support for pay-in-advance orders: the system now charges only the specified advance payment percentage instead of the full amount when `payInAdvance` is true.

### Why
To provide more flexibility for advance payment scenarios and improve tracking of partially paid invoices.

### Notes
- Invoices now clearly show the advance payment made and the remaining amount due.  
- Ensures proper handling and transparency of partial payments in `PortalAppConfig`.  
