### PR TITLE
feat: add support for partial invoice for pay-in-advance orders (#100907)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
@@ -15,6 +15,7 @@ import {createStripeOrder, findStripeOrder} from '@/payment/stripe/actions';
 import {manager, type Tenant} from '@/tenant';
 import {PaymentOption} from '@/types';
 import {computeTotal} from '@/utils/cart';
+import {calculateAdvanceAmount} from '@/utils/payment';
 
 // ---- LOCAL IMPORTS ---- //
 import {findGooveeUserByEmail} from '@/orm/partner';
@@ -115,6 +116,22 @@ async function createOrder({
 
     const {invoicingAddress, deliveryAddress} = cart;
 
+    const payInAdvance = workspace.config?.payInAdvance;
+    const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+    let expectedAmount;
+    if (
+      payInAdvance &&
+      advancePaymentPercentage &&
+      Number(advancePaymentPercentage) > 0
+    ) {
+      expectedAmount = calculateAdvanceAmount({
+        amount: Number(total),
+        percentage: Number(advancePaymentPercentage),
+        payInAdvance,
+      }).toString();
+    }
+
     const payload = {
       partnerId,
       contactId,
@@ -135,6 +152,7 @@ async function createOrder({
       workspaceId: workspace.id,
       invocingPartnerAddressId: invoicingAddress,
       deliveryPartnerAddressId: deliveryAddress,
+      ...(expectedAmount ? {paidAmount: expectedAmount} : {}),
     };
 
     const res = await axios.post(ws, payload, {
@@ -279,7 +297,23 @@ export async function paypalCaptureOrder({
       formatNumber,
     });
 
-    if (Number(amount) !== Number(total)) {
+    const payInAdvance = workspace.config?.payInAdvance;
+    const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+    let expectedAmount = total;
+    if (
+      payInAdvance &&
+      advancePaymentPercentage &&
+      Number(advancePaymentPercentage) > 0
+    ) {
+      expectedAmount = calculateAdvanceAmount({
+        amount: Number(total),
+        percentage: Number(advancePaymentPercentage),
+        payInAdvance,
+      }).toString();
+    }
+
+    if (Number(amount) !== Number(expectedAmount)) {
       return {
         error: true,
         message: await t('Amount mismatched'),
@@ -412,13 +446,29 @@ export async function paypalCreateOrder({
     formatNumber,
   });
 
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+  let expectedAmount = total;
+  if (
+    payInAdvance &&
+    advancePaymentPercentage &&
+    Number(advancePaymentPercentage) > 0
+  ) {
+    expectedAmount = calculateAdvanceAmount({
+      amount: Number(total),
+      percentage: Number(advancePaymentPercentage),
+      payInAdvance,
+    }).toString();
+  }
+
   const payer = await findGooveeUserByEmail(user?.email, tenantId);
 
   try {
     const response = await createPaypalOrder({
       tenantId,
       context: cart,
-      amount: total,
+      amount: expectedAmount,
       currency: currency?.code,
       email: payer?.emailAddress?.address!,
     });
@@ -544,6 +594,22 @@ export async function createStripeCheckoutSession({
     formatNumber,
   });
 
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+  let expectedAmount = total;
+  if (
+    payInAdvance &&
+    advancePaymentPercentage &&
+    Number(advancePaymentPercentage) > 0
+  ) {
+    expectedAmount = calculateAdvanceAmount({
+      amount: Number(total),
+      percentage: Number(advancePaymentPercentage),
+      payInAdvance,
+    }).toString();
+  }
+
   const payer = await findGooveeUserByEmail(user.email, tenantId);
 
   const currencyCode = currency?.code || DEFAULT_CURRENCY_CODE;
@@ -556,7 +622,7 @@ export async function createStripeCheckoutSession({
         email: payer?.emailAddress?.address!,
       },
       name: 'Cart Checkout',
-      amount: Number(total),
+      amount: Number(expectedAmount),
       currency: currencyCode,
       context: cart,
       url: {
@@ -705,10 +771,26 @@ export async function validateStripePayment({
     formatNumber,
   });
 
-  if (Number(paidAmount) !== Number(total)) {
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+  let expectedAmount = total;
+  if (
+    payInAdvance &&
+    advancePaymentPercentage &&
+    Number(advancePaymentPercentage) > 0
+  ) {
+    expectedAmount = calculateAdvanceAmount({
+      amount: Number(total),
+      percentage: Number(advancePaymentPercentage),
+      payInAdvance,
+    }).toString();
+  }
+
+  if (Number(paidAmount) !== Number(expectedAmount)) {
     return {
       error: true,
-      message: await t('Payment amount mistmatch'),
+      message: await t('Payment amount mismatch'),
     };
   }
 
@@ -834,12 +916,28 @@ export async function payboxCreateOrder({
     formatNumber,
   });
 
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+  let expectedAmount = total;
+  if (
+    payInAdvance &&
+    advancePaymentPercentage &&
+    Number(advancePaymentPercentage) > 0
+  ) {
+    expectedAmount = calculateAdvanceAmount({
+      amount: Number(total),
+      percentage: Number(advancePaymentPercentage),
+      payInAdvance,
+    }).toString();
+  }
+
   const payer = await findGooveeUserByEmail(user?.email, tenantId);
 
   try {
     const response = await createPayboxOrder({
       tenantId,
-      amount: total,
+      amount: expectedAmount,
       currency: currency?.code,
       email: payer?.emailAddress?.address!,
       context: cart,
@@ -983,10 +1081,28 @@ export async function validatePayboxPayment({
     formatNumber,
   });
 
-  if (Number(total) !== Number(paidAmount)) {
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
+  let expectedAmount = Number(total);
+  if (
+    payInAdvance &&
+    advancePaymentPercentage &&
+    Number(advancePaymentPercentage) > 0
+  ) {
+    expectedAmount = Number(
+      calculateAdvanceAmount({
+        amount: Number(total),
+        percentage: Number(advancePaymentPercentage),
+        payInAdvance,
+      }),
+    );
+  }
+
+  if (Number(paidAmount) !== expectedAmount) {
     return {
       error: true,
-      message: await t('Payment amount mistmatch'),
+      message: await t('Payment amount mismatch'),
     };
   }
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/content.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/content.tsx
@@ -27,6 +27,7 @@ import {i18n} from '@/locale';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
 import {type PortalWorkspace} from '@/types';
 import {formatNumber} from '@/locale/formatters';
+import {calculateAdvanceAmount} from '@/utils/payment';
 
 // ---- LOCAL IMPORTS ---- //
 import {findProduct} from '@/subapps/shop/common/actions/cart';
@@ -92,13 +93,26 @@ function Total({cart, shippingType, workspace}: any) {
     scale: {currency: currencyScale},
     currency: {symbol: currencySymbol},
   } = computeTotal({cart, workspace});
+
+  const payInAdvance = workspace.config?.payInAdvance;
+  const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
+
   const shipping = Number(
     scale(SHIPPING_TYPE_COST[shippingType], currencyScale),
   ) as number;
-  const totalWithShipping = formatNumber(Number(total) + Number(shipping), {
+
+  const totalAmount = Number(total) + Number(shipping);
+
+  const totalWithShipping = formatNumber(totalAmount, {
     currency: currencySymbol,
     scale: currencyScale,
     type: 'DECIMAL',
+  });
+
+  const advanceAmount = calculateAdvanceAmount({
+    amount: Number(total),
+    percentage: advancePaymentPercentage,
+    payInAdvance,
   });
 
   return (
@@ -130,6 +144,23 @@ function Total({cart, shippingType, workspace}: any) {
           <p className="text-xl font-semibold">{`${totalWithShipping} `}</p>
         </div>
       </div>
+      {payInAdvance && advanceAmount && (
+        <>
+          <Separator className="my-4" />
+          <div className="flex items-center justify-between">
+            <p className="font-medium">{i18n.t('Advance Amount Due')}:</p>
+            <div>
+              <p className="text-lg font-semibold">
+                {formatNumber(advanceAmount, {
+                  currency: currencySymbol,
+                  scale: currencyScale,
+                  type: 'DECIMAL',
+                })}
+              </p>
+            </div>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/changelogs/unreleased/100907.json
+++ b/changelogs/unreleased/100907.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add support for partial invoice for pay-in-advance orders",
+  "type": "feature",
+  "description": "Generates an invoice for the advance payment percentage when pay-in-advance is enabled.",
+  "scope": ["shop"]
+}

--- a/goovee/schema/AOSPortalAppConfig.json
+++ b/goovee/schema/AOSPortalAppConfig.json
@@ -354,6 +354,10 @@
     {
       "name": "hidePriceForEmptyPricelist",
       "type": "Boolean"
+    },
+    {
+      "name": "advancePaymentPercentage",
+      "type": "Decimal"
     }
   ]
 }

--- a/orm/workspace.ts
+++ b/orm/workspace.ts
@@ -120,6 +120,8 @@ export const portalAppConfigFields: SelectOptions<AOSPortalAppConfig> = {
   contactName: true,
   contactPhone: true,
   isCompanyOrAddressRequired: true,
+  payInAdvance: true,
+  advancePaymentPercentage: true,
 };
 
 export async function findWorkspaceMembers({

--- a/types/index.ts
+++ b/types/index.ts
@@ -77,7 +77,6 @@ export interface PortalAppConfig extends Model {
   displayTwoPrices: string;
   mainPrice: string;
   eSignature: boolean;
-  payInAdvance: boolean;
   priceAfterLogin: string;
   hidePriceForEmptyPricelist: boolean;
   requestQuotation: boolean;
@@ -166,6 +165,8 @@ export interface PortalAppConfig extends Model {
   contactEmailAddress?: {address?: string};
   contactPhone?: string;
   isCompanyOrAddressRequired?: boolean;
+  payInAdvance?: boolean;
+  advancePaymentPercentage?: BigDecimal;
 }
 
 export interface PortalApp extends Model {

--- a/utils/payment.ts
+++ b/utils/payment.ts
@@ -4,3 +4,22 @@ export const isPaymentOptionAvailable = (
   paymentOptions: any[] = [],
   type: PaymentOption,
 ) => paymentOptions.some((option: any) => option?.typeSelect === type);
+
+export function calculateAdvanceAmount({
+  amount,
+  percentage,
+  payInAdvance,
+}: {
+  amount: number;
+  percentage?: string | number;
+  payInAdvance?: boolean;
+}): number {
+  if (!payInAdvance || !percentage) return amount;
+
+  const amountNum = Number(amount);
+  const percent = Number(percentage ?? 0);
+
+  if (isNaN(percent) || percent <= 0) return amount;
+
+  return (amountNum * percent) / 100;
+}


### PR DESCRIPTION
### What’s Added
Partial payment support for pay-in-advance orders: the system now charges only the specified advance payment percentage instead of the full amount when `payInAdvance` is true.

### Why
To provide more flexibility for advance payment scenarios and improve tracking of partially paid invoices.

### Notes
- Invoices now clearly show the advance payment made and the remaining amount due.  
- Ensures proper handling and transparency of partial payments in `PortalAppConfig`.  
