### PR TITLE
fix(addresses): resolve type issues and support contact addresses

### DIFF
--- a/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
@@ -10,8 +10,6 @@ import {getSession} from '@/auth';
 import {findSubappAccess, findWorkspace} from '@/orm/workspace';
 import {clone} from '@/utils';
 import {
-  findCities,
-  findCountry,
   updateDefaultDeliveryAddress,
   updateDefaultInvoicingAddress,
 } from '@/orm/address';
@@ -32,26 +30,30 @@ export async function createAddress(values: Partial<PartnerAddress>) {
 
   if (!(session && tenantId)) return null;
 
-  const address = await createPartnerAddress(
-    session.user?.id,
-    values,
-    tenantId,
-  ).then(clone);
+  const userId = session?.user.isContact
+    ? session?.user.mainPartnerId!
+    : session?.user.id!;
+
+  const address = await createPartnerAddress(userId, values, tenantId).then(
+    clone,
+  );
 
   return address;
 }
 
-export async function updateAddress(values: Partial<PartnerAddress>) {
+export async function updateAddress(values: PartnerAddress) {
   const session = await getSession();
   const tenantId = headers().get(TENANT_HEADER);
 
   if (!(session && tenantId)) return null;
 
-  const address = await updatePartnerAddress(
-    session.user?.id,
-    values,
-    tenantId,
-  ).then(clone);
+  const userId = session?.user.isContact
+    ? session?.user.mainPartnerId!
+    : session?.user.id!;
+
+  const address = await updatePartnerAddress(userId, values, tenantId).then(
+    clone,
+  );
 
   return address;
 }
@@ -75,7 +77,11 @@ export async function updateDefaultAddress({
       ? updateDefaultDeliveryAddress
       : updateDefaultInvoicingAddress;
 
-  return updateHandler(id, session?.user?.id, tenantId, isDefault).then(clone);
+  const userId = session?.user.isContact
+    ? session?.user.mainPartnerId!
+    : session?.user.id!;
+
+  return updateHandler(id, userId, tenantId, isDefault).then(clone);
 }
 
 export async function deleteAddress(id: PartnerAddress['id']) {

--- a/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
@@ -81,7 +81,12 @@ export async function updateDefaultAddress({
     ? session?.user.mainPartnerId!
     : session?.user.id!;
 
-  return updateHandler(id, userId, tenantId, isDefault).then(clone);
+  return updateHandler({
+    partnerAddressId: id,
+    partnerId: userId,
+    tenantId,
+    isDefault,
+  }).then(clone);
 }
 
 export async function deleteAddress(id: PartnerAddress['id']) {

--- a/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-form/address-form.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-form/address-form.tsx
@@ -11,7 +11,7 @@ import {capitalise} from '@/utils';
 import {ADDRESS_TYPE, SUBAPP_PAGE} from '@/constants';
 import {i18n} from '@/locale';
 import {Button, Form} from '@/ui/components';
-import {Country} from '@/types';
+import {City, Country} from '@/types';
 import {useSearchParams, useToast} from '@/ui/hooks';
 import {useWorkspace} from '@/app/[tenant]/[workspace]/workspace-context';
 import {UserType} from '@/lib/core/auth/types';
@@ -38,6 +38,7 @@ const addressInformationSchema = z.object({
   country: z.object({
     id: z.string().min(1, i18n.t('Country is required')),
     name: z.string().min(1, i18n.t('Country name is required')),
+    version: z.number(),
   }),
   streetName: z.string().min(1, i18n.t('Street name is required')),
   addressAddition: z.string().optional(),
@@ -90,6 +91,7 @@ export const AddressForm = ({
         country: {
           id: address?.address?.country?.id ?? '',
           name: address?.address?.country?.name ?? '',
+          version: address?.address?.country?.version ?? '',
         },
         streetName: address?.address?.streetName ?? '',
         addressAddition: address?.address?.countrySubDivision ?? '',
@@ -100,9 +102,6 @@ export const AddressForm = ({
     },
   });
 
-  const country = form.watch('addressInformation.country');
-  const zip = form.watch('addressInformation.zip');
-
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     const {addressInformation, personalInformation} = values;
     const {multipletype, townName, country, addressAddition, streetName, zip} =
@@ -111,6 +110,7 @@ export const AddressForm = ({
 
     const isDeliveryAddr = multipletype || type === ADDRESS_TYPE.delivery;
     const isInvoicingAddr = multipletype || type === ADDRESS_TYPE.invoicing;
+    const isDefaultAddr = address?.isDefaultAddr;
 
     const computeFullName = () => {
       return [streetName, addressAddition, zip, townName]
@@ -126,7 +126,9 @@ export const AddressForm = ({
     };
 
     const addressBody = {
-      country: country.id,
+      id: address?.address?.id,
+      version: address?.address?.version,
+      country,
       addressl2: addressName,
       addressl4: streetName,
       addressl3: addressAddition,
@@ -146,10 +148,12 @@ export const AddressForm = ({
     try {
       const action = address ? updateAddress : createAddress;
       const result = await action({
-        address: addressBody as any,
+        address: addressBody,
         id: address?.id,
         isInvoicingAddr,
         isDeliveryAddr,
+        isDefaultAddr,
+        version: address?.version,
       });
 
       if (result) {

--- a/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
@@ -136,7 +136,7 @@ export function AddressInformation({countries, form}: AddressInformationProps) {
                   <span className="text-destructive">*</span>
                 </FormLabel>
                 <FormControl>
-                  <Input placeholder={i18n.t('Enter city name')} {...field} />
+                  <Input placeholder={i18n.t('Enter town name')} {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/common/ui/components/address-information/address-information.tsx
@@ -22,7 +22,11 @@ interface AddressInformationProps {
 }
 
 export function AddressInformation({countries, form}: AddressInformationProps) {
-  const handleCountryChange = (selectedOption: {id: string; name: string}) => {
+  const handleCountryChange = (selectedOption: {
+    id: string;
+    name: string;
+    version: number;
+  }) => {
     form.setValue('addressInformation.country', selectedOption, {
       shouldValidate: true,
     });

--- a/app/[tenant]/[workspace]/account/addresses/page.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/page.tsx
@@ -122,8 +122,10 @@ export default async function Page({params, searchParams}: PageParams) {
     data = quotation;
   }
 
+  const userId = user.isContact ? user.mainPartnerId! : user.id!;
+
   const {deliveryAddresses, invoicingAddresses} = await fetchAddresses(
-    user.id,
+    userId,
     tenant,
   );
 

--- a/changelogs/unreleased/103130.json
+++ b/changelogs/unreleased/103130.json
@@ -1,0 +1,6 @@
+{
+  "title": "Add Support for Managing Addresses for Contacts",
+  "type": "feature",
+  "description": "Ensures consistent address handling across Partners and Contacts",
+  "scope": ["users"]
+}

--- a/orm/address.ts
+++ b/orm/address.ts
@@ -281,12 +281,17 @@ export async function findDefaultDeliveryAddress(
   return result;
 }
 
-export async function updateDefaultDeliveryAddress(
-  partnerAddressId: PartnerAddress['id'],
-  partnerId: Partner['id'],
-  tenantId: Tenant['id'],
-  isDefault?: boolean,
-) {
+export async function updateDefaultDeliveryAddress({
+  partnerAddressId,
+  partnerId,
+  tenantId,
+  isDefault,
+}: {
+  partnerAddressId: PartnerAddress['id'];
+  partnerId: Partner['id'];
+  tenantId: Tenant['id'];
+  isDefault?: boolean;
+}) {
   if (!(partnerAddressId && partnerId && tenantId)) return null;
 
   const client = await manager.getClient(tenantId);
@@ -377,12 +382,17 @@ export async function findDefaultInvoicingAddress(
   return result;
 }
 
-export async function updateDefaultInvoicingAddress(
-  partnerAddressId: PartnerAddress['id'],
-  partnerId: Partner['id'],
-  tenantId: Tenant['id'],
-  isDefault?: boolean,
-) {
+export async function updateDefaultInvoicingAddress({
+  partnerAddressId,
+  partnerId,
+  tenantId,
+  isDefault,
+}: {
+  partnerAddressId: PartnerAddress['id'];
+  partnerId: Partner['id'];
+  tenantId: Tenant['id'];
+  isDefault?: boolean;
+}) {
   if (!(partnerAddressId && partnerId && tenantId)) return null;
 
   const client = await manager.getClient(tenantId);

--- a/orm/address.ts
+++ b/orm/address.ts
@@ -66,7 +66,7 @@ export async function createPartnerAddress(
           ...values.address,
           country: {
             select: {
-              id: values?.address?.country,
+              id: values?.address?.country?.id,
             },
           },
           townName: values?.address?.townName,
@@ -78,10 +78,10 @@ export async function createPartnerAddress(
     },
   });
 
-  if (values.isDeliveryAddr && values?.address?.country) {
+  if (values.isDeliveryAddr && values?.address?.country?.id) {
     await updatePartnerFiscal({
       partnerId,
-      countryId: values.address.country,
+      countryId: values.address.country.id,
       tenantId,
       isDeliveryAddr: values.isDeliveryAddr,
       isDefaultAddr: values.isDefaultAddr,
@@ -115,7 +115,7 @@ export async function updatePartnerAddress(
           ...values.address,
           country: {
             select: {
-              id: values?.address?.country,
+              id: values?.address?.country?.id,
             },
           },
           townName: values?.address?.townName,
@@ -127,10 +127,10 @@ export async function updatePartnerAddress(
     },
   });
 
-  if (values.isDeliveryAddr && values?.address?.country) {
+  if (values.isDeliveryAddr && values?.address?.country?.id) {
     await updatePartnerFiscal({
       partnerId,
-      countryId: values.address.country,
+      countryId: values.address.country.id,
       tenantId,
       isDeliveryAddr: address?.isDeliveryAddr,
       isDefaultAddr: address?.isDefaultAddr,
@@ -472,37 +472,6 @@ export async function findCountry({
   } catch (error) {
     console.log('error:', error);
     return null;
-  }
-}
-
-export async function findCities({
-  countryId,
-  tenantId,
-  zip,
-}: {
-  countryId: string | number;
-  tenantId: Tenant['id'];
-  zip: string;
-}): Promise<City[]> {
-  if (!tenantId || !countryId || !zip) return [];
-
-  try {
-    const client = await manager.getClient(tenantId);
-
-    const cities = await client.aOSCity.find({
-      where: {
-        country: {id: countryId},
-        zip,
-      },
-    });
-
-    return cities.map(city => ({
-      id: city.id,
-      name: city.name,
-    })) as City[];
-  } catch (error) {
-    console.error('Error fetching cities:', error);
-    return [];
   }
 }
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -138,7 +138,7 @@
   "Enter attachment description": "Enter attachment description",
   "Enter attachment title": "Enter attachment title",
   "Enter category description": "Enter category description",
-  "Enter city name": "Enter city name",
+  "Enter town name": "Enter town name",
   "Enter company SIRET number": "Enter company SIRET number",
   "Enter company name": "Enter company name",
   "Enter company number": "Enter company number",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -138,7 +138,7 @@
   "Enter attachment description": "Entrer la description de la pièce jointe",
   "Enter attachment title": "Entrer le titre de la pièce jointe",
   "Enter category description": "Entrer la description de la catégorie",
-  "Enter city name": "Entrer le nom de la ville",
+  "Enter town name": "Entrez le nom de la ville",
   "Enter company SIRET number": "Entrer le numéro SIRET de l’entreprise",
   "Enter company name": "Entrer le nom de l’entreprise",
   "Enter company number": "Entrer le numéro de l’entreprise",

--- a/ui/components/dropdown-selector/dropdown-selector.tsx
+++ b/ui/components/dropdown-selector/dropdown-selector.tsx
@@ -13,8 +13,13 @@ import {
 } from '@/ui/components';
 import {cn} from '@/utils/css';
 
-type DropdownSelectorProps = {
-  options: any[];
+type DropdownOptionBase = {
+  id: string | number;
+  name: string;
+};
+
+type DropdownSelectorProps<T extends DropdownOptionBase> = {
+  options: T[];
   label: string;
   placeholder?: string;
   selectedValue?: string;
@@ -23,10 +28,10 @@ type DropdownSelectorProps = {
   isRequired?: boolean;
   disabled?: boolean;
   hasError?: boolean;
-  onValueChange: (selectedOption: {id: string; name: string}) => void;
+  onValueChange: (selectedOption: T) => void;
 };
 
-export function DropdownSelector({
+export function DropdownSelector<T extends DropdownOptionBase>({
   options = [],
   label,
   placeholder = 'Select an option',
@@ -37,7 +42,7 @@ export function DropdownSelector({
   disabled,
   hasError,
   onValueChange,
-}: DropdownSelectorProps) {
+}: DropdownSelectorProps<T>) {
   return (
     <div className={rootClassName}>
       <Label
@@ -52,7 +57,9 @@ export function DropdownSelector({
         disabled={disabled}
         onValueChange={(value: string) => {
           const selectedOption = options.find(option => option.id === value);
-          onValueChange(selectedOption);
+          if (selectedOption) {
+            onValueChange(selectedOption);
+          }
         }}>
         <SelectTrigger className="w-full">
           <SelectValue placeholder={placeholder} />
@@ -61,7 +68,7 @@ export function DropdownSelector({
           <SelectGroup>
             <SelectLabel>{label}</SelectLabel>
             {options.map(option => (
-              <SelectItem key={option.id} value={option.id}>
+              <SelectItem key={option.id} value={String(option.id)}>
                 {option.name}
               </SelectItem>
             ))}


### PR DESCRIPTION
### What’s Added
Introduced support for managing addresses for Contacts, ensuring address handling is consistent across both Partners and Contacts.

### Why
Previously, address functionality was limited to Partners. This update brings parity to Contacts, improving data completeness and enabling better contact management.

### Notes
- Added support for fetching addresses associated with Contacts
- Resolved type inconsistencies in Address and PartnerAddress models
- Improved address handling logic for both create and update operations
- Ensured city and country fields are correctly typed and validated