### PR TITLE
fix: restrict contact-based address selection to partner addresses in Shop and Quotations (#103363)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/events/common/orm/partner.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/orm/partner.ts
@@ -4,6 +4,7 @@ import {manager, type Tenant} from '@/tenant';
 import {getSession} from '@/lib/core/auth';
 import {and} from '@/utils/orm';
 import type {AOSPartner} from '@/goovee/.generated/models';
+import {getPartnerId} from '@/utils';
 
 // ---- LOCAL IMPORTS ---- //
 import {
@@ -36,7 +37,7 @@ export async function findContacts({
     return null;
   }
 
-  const partnerId = user.isContact ? user.mainPartnerId : user.id;
+  const partnerId = getPartnerId(user);
 
   const c = await manager.getClient(tenantId);
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/address.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/address.ts
@@ -2,6 +2,7 @@
 
 import {headers} from 'next/headers';
 
+// ---- CORE IMPORTS ---- //
 import {getSession} from '@/auth';
 import {TENANT_HEADER} from '@/middleware';
 import {
@@ -12,7 +13,7 @@ import {
   findPartnerAddress,
 } from '@/orm/address';
 import type {ID} from '@/types';
-import {clone} from '@/utils';
+import {clone, getUserId} from '@/utils';
 
 export async function findDefaultInvoicing() {
   const session = await getSession();
@@ -22,7 +23,9 @@ export async function findDefaultInvoicing() {
 
   if (!(user && tenantId)) return null;
 
-  return findDefaultInvoicingAddress(user.id, tenantId).then(clone);
+  const userId = getUserId(user);
+
+  return findDefaultInvoicingAddress(userId, tenantId).then(clone);
 }
 
 export async function findDefaultDelivery() {
@@ -33,7 +36,9 @@ export async function findDefaultDelivery() {
 
   if (!(user && tenantId)) return null;
 
-  return findDefaultDeliveryAddress(user.id, tenantId).then(clone);
+  const userId = getUserId(user);
+
+  return findDefaultDeliveryAddress(userId, tenantId).then(clone);
 }
 
 export async function findAddress(id: ID) {
@@ -44,7 +49,11 @@ export async function findAddress(id: ID) {
 
   if (!(user && tenantId)) return null;
 
-  return findPartnerAddress(id, tenantId).then(clone);
+  const userId = getUserId(user);
+
+  return findPartnerAddress({partnerId: userId, addressId: id, tenantId}).then(
+    clone,
+  );
 }
 
 export async function fetchDeliveryAddresses() {
@@ -55,7 +64,9 @@ export async function fetchDeliveryAddresses() {
 
   if (!(user && tenantId)) return null;
 
-  return findDeliveryAddresses(user.id, tenantId).then(clone);
+  const userId = getUserId(user);
+
+  return findDeliveryAddresses(userId, tenantId).then(clone);
 }
 
 export async function fetchInvoicingAddresses() {
@@ -66,5 +77,7 @@ export async function fetchInvoicingAddresses() {
 
   if (!(user && tenantId)) return null;
 
-  return findInvoicingAddresses(user.id, tenantId).then(clone);
+  const userId = getUserId(user);
+
+  return findInvoicingAddresses(userId, tenantId).then(clone);
 }

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/address.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/address.ts
@@ -13,7 +13,7 @@ import {
   findPartnerAddress,
 } from '@/orm/address';
 import type {ID} from '@/types';
-import {clone, getUserId} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 
 export async function findDefaultInvoicing() {
   const session = await getSession();
@@ -23,7 +23,7 @@ export async function findDefaultInvoicing() {
 
   if (!(user && tenantId)) return null;
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   return findDefaultInvoicingAddress(userId, tenantId).then(clone);
 }
@@ -36,7 +36,7 @@ export async function findDefaultDelivery() {
 
   if (!(user && tenantId)) return null;
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   return findDefaultDeliveryAddress(userId, tenantId).then(clone);
 }
@@ -49,7 +49,7 @@ export async function findAddress(id: ID) {
 
   if (!(user && tenantId)) return null;
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   return findPartnerAddress({partnerId: userId, addressId: id, tenantId}).then(
     clone,
@@ -64,7 +64,7 @@ export async function fetchDeliveryAddresses() {
 
   if (!(user && tenantId)) return null;
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   return findDeliveryAddresses(userId, tenantId).then(clone);
 }
@@ -77,7 +77,7 @@ export async function fetchInvoicingAddresses() {
 
   if (!(user && tenantId)) return null;
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   return findInvoicingAddresses(userId, tenantId).then(clone);
 }

--- a/app/[tenant]/[workspace]/account/(ee)/members/invite/action.ts
+++ b/app/[tenant]/[workspace]/account/(ee)/members/invite/action.ts
@@ -19,6 +19,7 @@ import {findWorkspace} from '@/orm/workspace';
 import NotificationManager, {NotificationType} from '@/notification';
 import {SEARCH_PARAMS} from '@/constants';
 import type {PortalWorkspace} from '@/types';
+import {getPartnerId} from '@/utils';
 
 // ---- LOCAL IMPORTS ---- //
 import {inviteTemplate} from '../../../common/constants/template';
@@ -188,7 +189,7 @@ export async function sendInvites({
 
   let inviteError;
 
-  const partnerId = (user.isContact ? user.mainPartnerId : user.id) as any;
+  const partnerId = getPartnerId(user);
 
   const partner = await findPartnerById(partnerId, tenantId);
 

--- a/app/[tenant]/[workspace]/account/addresses/[type]/edit/[address_id]/page.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/[type]/edit/[address_id]/page.tsx
@@ -3,7 +3,7 @@ import {notFound} from 'next/navigation';
 
 // ---- CORE IMPORRS ---- //
 import {ADDRESS_TYPE, SUBAPP_PAGE} from '@/constants';
-import {clone, getUserId} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {getSession} from '@/auth';
 import {findCountries, findPartnerAddress} from '@/orm/address';
 import {findGooveeUserByEmail, PartnerTypeMap} from '@/orm/partner';
@@ -52,7 +52,7 @@ export default async function Page({
 
   const countries: any = await findCountries(tenant).then(clone);
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   const partnerAddress = await findPartnerAddress({
     partnerId: userId,

--- a/app/[tenant]/[workspace]/account/addresses/[type]/edit/[address_id]/page.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/[type]/edit/[address_id]/page.tsx
@@ -3,7 +3,7 @@ import {notFound} from 'next/navigation';
 
 // ---- CORE IMPORRS ---- //
 import {ADDRESS_TYPE, SUBAPP_PAGE} from '@/constants';
-import {clone} from '@/utils';
+import {clone, getUserId} from '@/utils';
 import {getSession} from '@/auth';
 import {findCountries, findPartnerAddress} from '@/orm/address';
 import {findGooveeUserByEmail, PartnerTypeMap} from '@/orm/partner';
@@ -52,9 +52,13 @@ export default async function Page({
 
   const countries: any = await findCountries(tenant).then(clone);
 
-  const partnerAddress = await findPartnerAddress(address_id, tenant).then(
-    clone,
-  );
+  const userId = getUserId(user);
+
+  const partnerAddress = await findPartnerAddress({
+    partnerId: userId,
+    addressId: address_id,
+    tenantId: tenant,
+  }).then(clone);
 
   if (!partnerAddress) {
     redirect(`${REDIRECT_ADDRESS_URL}`);

--- a/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
@@ -8,7 +8,7 @@ import {t} from '@/locale/server';
 import {ADDRESS_TYPE, SUBAPP_CODES} from '@/constants';
 import {getSession} from '@/auth';
 import {findSubappAccess, findWorkspace} from '@/orm/workspace';
-import {clone} from '@/utils';
+import {clone, getUserId} from '@/utils';
 import {
   updateDefaultDeliveryAddress,
   updateDefaultInvoicingAddress,
@@ -30,9 +30,7 @@ export async function createAddress(values: Partial<PartnerAddress>) {
 
   if (!(session && tenantId)) return null;
 
-  const userId = session?.user.isContact
-    ? session?.user.mainPartnerId!
-    : session?.user.id!;
+  const userId = getUserId(session?.user);
 
   const address = await createPartnerAddress(userId, values, tenantId).then(
     clone,
@@ -47,9 +45,7 @@ export async function updateAddress(values: PartnerAddress) {
 
   if (!(session && tenantId)) return null;
 
-  const userId = session?.user.isContact
-    ? session?.user.mainPartnerId!
-    : session?.user.id!;
+  const userId = getUserId(session?.user);
 
   const address = await updatePartnerAddress(userId, values, tenantId).then(
     clone,
@@ -77,9 +73,7 @@ export async function updateDefaultAddress({
       ? updateDefaultDeliveryAddress
       : updateDefaultInvoicingAddress;
 
-  const userId = session?.user.isContact
-    ? session?.user.mainPartnerId!
-    : session?.user.id!;
+  const userId = getUserId(session?.user);
 
   return updateHandler({
     partnerAddressId: id,
@@ -95,11 +89,10 @@ export async function deleteAddress(id: PartnerAddress['id']) {
 
   if (!(session?.user && tenantId && id)) return null;
 
-  const address = await deletePartnerAddress(
-    session.user?.id,
-    id,
-    tenantId,
-  ).then(clone);
+  const {user} = session;
+  const userId = getUserId(user);
+
+  const address = await deletePartnerAddress(userId, id, tenantId).then(clone);
 
   return address;
 }

--- a/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/account/addresses/common/actions/action.ts
@@ -8,7 +8,7 @@ import {t} from '@/locale/server';
 import {ADDRESS_TYPE, SUBAPP_CODES} from '@/constants';
 import {getSession} from '@/auth';
 import {findSubappAccess, findWorkspace} from '@/orm/workspace';
-import {clone, getUserId} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {
   updateDefaultDeliveryAddress,
   updateDefaultInvoicingAddress,
@@ -30,7 +30,7 @@ export async function createAddress(values: Partial<PartnerAddress>) {
 
   if (!(session && tenantId)) return null;
 
-  const userId = getUserId(session?.user);
+  const userId = getPartnerId(session?.user);
 
   const address = await createPartnerAddress(userId, values, tenantId).then(
     clone,
@@ -45,7 +45,7 @@ export async function updateAddress(values: PartnerAddress) {
 
   if (!(session && tenantId)) return null;
 
-  const userId = getUserId(session?.user);
+  const userId = getPartnerId(session?.user);
 
   const address = await updatePartnerAddress(userId, values, tenantId).then(
     clone,
@@ -73,7 +73,7 @@ export async function updateDefaultAddress({
       ? updateDefaultDeliveryAddress
       : updateDefaultInvoicingAddress;
 
-  const userId = getUserId(session?.user);
+  const userId = getPartnerId(session?.user);
 
   return updateHandler({
     partnerAddressId: id,
@@ -90,7 +90,7 @@ export async function deleteAddress(id: PartnerAddress['id']) {
   if (!(session?.user && tenantId && id)) return null;
 
   const {user} = session;
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   const address = await deletePartnerAddress(userId, id, tenantId).then(clone);
 

--- a/app/[tenant]/[workspace]/account/addresses/page.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/page.tsx
@@ -1,7 +1,7 @@
 import {notFound} from 'next/navigation';
 
 // ---- CORE IMPORTS ---- //
-import {clone} from '@/utils';
+import {clone, getUserId} from '@/utils';
 import {getSession} from '@/auth';
 import {workspacePathname} from '@/utils/workspace';
 import {findSubappAccess} from '@/orm/workspace';
@@ -122,7 +122,7 @@ export default async function Page({params, searchParams}: PageParams) {
     data = quotation;
   }
 
-  const userId = user.isContact ? user.mainPartnerId! : user.id!;
+  const userId = getUserId(user);
 
   const {deliveryAddresses, invoicingAddresses} = await fetchAddresses(
     userId,

--- a/app/[tenant]/[workspace]/account/addresses/page.tsx
+++ b/app/[tenant]/[workspace]/account/addresses/page.tsx
@@ -1,7 +1,7 @@
 import {notFound} from 'next/navigation';
 
 // ---- CORE IMPORTS ---- //
-import {clone, getUserId} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {getSession} from '@/auth';
 import {workspacePathname} from '@/utils/workspace';
 import {findSubappAccess} from '@/orm/workspace';
@@ -122,7 +122,7 @@ export default async function Page({params, searchParams}: PageParams) {
     data = quotation;
   }
 
-  const userId = getUserId(user);
+  const userId = getPartnerId(user);
 
   const {deliveryAddresses, invoicingAddresses} = await fetchAddresses(
     userId,

--- a/app/[tenant]/[workspace]/account/common/orm/invites.ts
+++ b/app/[tenant]/[workspace]/account/common/orm/invites.ts
@@ -220,7 +220,7 @@ export async function createInvite({
   role: Role;
   email: string;
   apps: InviteAppsConfig;
-  partnerId: string;
+  partnerId: Partner['id'];
 }) {
   if (!(workspace?.id && tenantId && role && email && apps && partnerId)) {
     return null;

--- a/app/[tenant]/[workspace]/account/personal/action.ts
+++ b/app/[tenant]/[workspace]/account/personal/action.ts
@@ -7,13 +7,12 @@ import {promisify} from 'util';
 import {headers} from 'next/headers';
 
 // ---- CORE IMPORTS ---- //
-
 import {manager} from '@/lib/core/tenant';
 import {getSession} from '@/auth';
 import {TENANT_HEADER} from '@/middleware';
 import {getFileSizeText} from '@/utils/files';
 import {getTranslation, t} from '@/locale/server';
-import {clone} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {
   PartnerTypeMap,
   findGooveeUserByEmail,
@@ -358,7 +357,7 @@ export async function generateOTPForUpdate({
     return error(await t('Bad request'));
   }
 
-  const partnerId = user.isContact ? user.mainPartnerId : user.id;
+  const partnerId = getPartnerId(user);
 
   const partner = await findPartnerById(partnerId!, tenantId);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import {
   findDefaultPartnerWorkspace,
 } from '@/orm/workspace';
 import {getSession} from '@/auth';
-import {clone} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {TenancyType, manager} from '@/tenant';
 import {DEFAULT_TENANT} from '@/constants';
 
@@ -60,7 +60,7 @@ export default async function Page({
   let redirectURL;
 
   if (user) {
-    const partnerId = user.isContact ? user.mainPartnerId : user.id;
+    const partnerId = getPartnerId(user);
 
     const defaultWorkspace = await findDefaultPartnerWorkspace({
       partnerId,

--- a/changelogs/unreleased/103363.json
+++ b/changelogs/unreleased/103363.json
@@ -1,6 +1,6 @@
 {
-  "title": "Enable contact-based address selection in Shop and Quotations",
+  "title": "Restrict Contact Address Selection to Partner Addresses in Shop and Quotations",
   "type": "fix",
-  "description": "Allow address selection based on the Contact associated with a transaction instead of being restricted to the Partner level. Added `getPartnerId` utility to ensure accurate partner resolution for contact-based transactions, improving flexibility and accuracy in Shop and Quotations modules.",
+  "description": "Implemented strict address filtering in Shop and Quotations. Contacts are now restricted to selecting only addresses associated with their parent Partner.",
   "scope": ["core", "shop", "quotations"]
 }

--- a/changelogs/unreleased/103363.json
+++ b/changelogs/unreleased/103363.json
@@ -1,0 +1,6 @@
+{
+  "title": "Enable contact-based address selection in Shop and Quotations",
+  "type": "fix",
+  "description": "Allow address selection based on the Contact associated with a transaction instead of being restricted to the Partner level. Added `getPartnerId` utility to ensure accurate partner resolution for contact-based transactions, improving flexibility and accuracy in Shop and Quotations modules.",
+  "scope": ["core", "shop", "quotations"]
+}

--- a/orm/address.ts
+++ b/orm/address.ts
@@ -1,5 +1,5 @@
 import {manager, type Tenant} from '@/tenant';
-import {PartnerAddress, Partner, ID, City} from '@/types';
+import {PartnerAddress, Partner, ID} from '@/types';
 
 const addressFields = {
   address: {
@@ -27,10 +27,15 @@ const addressFields = {
   isInvoicingAddr: true,
 };
 
-export async function findPartnerAddress(
-  addressId: PartnerAddress['id'],
-  tenantId: Tenant['id'],
-) {
+export async function findPartnerAddress({
+  partnerId,
+  addressId,
+  tenantId,
+}: {
+  partnerId: Partner['id'];
+  addressId: PartnerAddress['id'];
+  tenantId: Tenant['id'];
+}) {
   if (!(addressId && tenantId)) return null;
 
   const client = await manager.getClient(tenantId);
@@ -38,6 +43,9 @@ export async function findPartnerAddress(
   const address = await client.aOSPartnerAddress.findOne({
     where: {
       id: addressId,
+      partner: {
+        id: partnerId,
+      },
     },
     select: addressFields,
   });
@@ -100,7 +108,11 @@ export async function updatePartnerAddress(
 
   if (!(partnerId && tenantId && partnerAddressId)) return null;
 
-  const partnerAddress = await findPartnerAddress(partnerAddressId, tenantId);
+  const partnerAddress = await findPartnerAddress({
+    partnerId,
+    addressId: partnerAddressId,
+    tenantId,
+  });
 
   if (!partnerAddress) return null;
 

--- a/orm/product.ts
+++ b/orm/product.ts
@@ -1,5 +1,7 @@
+// ---- CORE IMPORTS ---- //
 import {type Tenant, manager} from '@/lib/core/tenant';
 import type {User, PortalWorkspace} from '@/types';
+import {getPartnerId} from '@/utils';
 
 export async function shouldHidePricesAndPurchase({
   user,
@@ -16,7 +18,7 @@ export async function shouldHidePricesAndPurchase({
     const client = await manager.getClient(tenantId);
     const mainPartner = await client.aOSPartner.findOne({
       where: {
-        id: user.isContact ? user.mainPartnerId : user.id,
+        id: getPartnerId(user),
       },
       select: {
         salePartnerPriceList: {id: true},

--- a/orm/workspace.ts
+++ b/orm/workspace.ts
@@ -1,7 +1,8 @@
+// ---- CORE IMPORTS ---- //
 import {manager, type Tenant} from '@/tenant';
 import {AOSPortalAppConfig} from '@/goovee/.generated/models';
 import {ID, Partner, PortalWorkspace, User} from '@/types';
-import {clone} from '@/utils';
+import {clone, getPartnerId} from '@/utils';
 import {SelectOptions} from '@goovee/orm';
 
 export const portalAppConfigFields: SelectOptions<AOSPortalAppConfig> = {
@@ -462,7 +463,7 @@ export async function findWorkspace({
   let workspaceConfig;
 
   if (user) {
-    const partnerId = user.isContact ? user.mainPartnerId : user.id;
+    const partnerId = getPartnerId(user);
 
     const partnerWorkspaceConfig = await findPartnerWorkspaceConfig({
       partnerId,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -94,6 +94,6 @@ export function htmlToNormalString(htmlString: string) {
   return plainText;
 }
 
-export function getUserId(user: User): number {
+export function getPartnerId(user: User): number {
   return Number(user.isContact ? user.mainPartnerId : user.id);
 }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,6 +2,7 @@ import {DEFAULT_SCALE} from '@/locale';
 import {DEFAULT_CURRENCY_SYMBOL} from '@/constants';
 
 import type {Cloned} from '@/types/util';
+import {User} from '@/types';
 
 export function clone<T>(obj: T): Cloned<T> {
   return obj && JSON.parse(JSON.stringify(obj));
@@ -91,4 +92,8 @@ export function htmlToNormalString(htmlString: string) {
   }
 
   return plainText;
+}
+
+export function getUserId(user: User): number {
+  return Number(user.isContact ? user.mainPartnerId : user.id);
 }


### PR DESCRIPTION
### What’s Added
Implemented a restriction on address selection in the Shop and Quotation app when the logged-in user is a Contact. Contacts are now strictly limited to selecting only the addresses associated with their parent Partner record.

### Why
The address management was restricted to partner-level entries, which caused inconvenience when contacts under the same partner required different delivery or billing addresses for Shop and Quotations.
This enhancement provides greater flexibility and accuracy by allowing users to select addresses tied directly to the active contact.

### Notes
- Ensure compatibility for contact-based address selection in Shop and Quotations
- Added getPartnerId utility to determine the correct partner ID based on the logged-in user.