### PR TITLE
fix(shop): correct mainPrice check and apply dynamic pricing

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
@@ -5,7 +5,7 @@ import {headers} from 'next/headers';
 
 // ---- CORE IMPORTS ---- //
 import {getSession} from '@/auth';
-import {DEFAULT_CURRENCY_CODE, SUBAPP_CODES} from '@/constants';
+import {DEFAULT_CURRENCY_CODE, MAIN_PRICE, SUBAPP_CODES} from '@/constants';
 import {t} from '@/locale/server';
 import {TENANT_HEADER} from '@/middleware';
 import {findSubappAccess, findWorkspace} from '@/orm/workspace';
@@ -155,21 +155,23 @@ async function createOrder({
       }).toString();
     }
 
+    const isAtiPricing = workspace?.config?.mainPrice === MAIN_PRICE.ATI;
     const payload = {
       partnerId,
       contactId,
       shipping: 0,
       total,
-      inAti: workspace?.config?.mainPrice === 'ati',
+      inAti: isAtiPricing,
       items: $cart.items.map((i: any) => {
         const {computedProduct, note, quantity} = i;
         if (!computedProduct) return null;
         const {product, price} = computedProduct;
+
         return {
           productId: product?.id,
           note: note || '',
           quantity,
-          price: price?.ati,
+          price: isAtiPricing ? price?.ati : price?.wt,
         };
       }),
       workspaceId: workspace.id,

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
@@ -10,6 +10,7 @@ import {computeTotal} from '@/utils/cart';
 import {TENANT_HEADER} from '@/middleware';
 import {manager} from '@/tenant';
 import type {PortalWorkspace, Product} from '@/types';
+import {MAIN_PRICE} from '@/constants';
 
 // ---- LOCAL IMPORTS ---- //
 import {findProduct as $findProduct} from '@/subapps/shop/common/orm/product';
@@ -71,7 +72,7 @@ export async function requestQuotation({
   });
 }
 
-export async function requestOrder({
+async function requestOrder({
   cart,
   workspace,
   type = 'order',
@@ -139,13 +140,14 @@ export async function requestOrder({
       }
     }
     const {invoicingAddress, deliveryAddress} = cart;
+    const isAtiPricing = workspace?.config?.mainPrice === MAIN_PRICE.ATI;
 
     const payload = {
       partnerId,
       contactId,
       shipping: 0,
       total,
-      inAti: workspace?.config?.mainPrice === 'ati',
+      inAti: isAtiPricing,
       items: $cart.items.map((i: any) => {
         const {computedProduct, note, quantity} = i;
         if (!computedProduct) return null;
@@ -154,7 +156,7 @@ export async function requestOrder({
           productId: product?.id,
           note: note || '',
           quantity,
-          price: price?.ati,
+          price: isAtiPricing ? price?.ati : price?.wt,
         };
       }),
       workspaceId: workspace.id,

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_PAGE,
   DEFAULT_TAX_VALUE,
   DEFAULT_UNIT_PRICE_SCALE,
+  MAIN_PRICE,
   OUT_OF_STOCK_TYPE,
 } from '@/constants';
 import type {
@@ -505,8 +506,8 @@ export async function findProducts({
         type: 'DECIMAL',
       })) as string;
 
-      let primary = mainPrice === 'at' ? ati : wt;
-      let secondary = mainPrice === 'at' ? wt : ati;
+      let primary = mainPrice === MAIN_PRICE.ATI ? ati : wt;
+      let secondary = mainPrice === MAIN_PRICE.ATI ? wt : ati;
 
       const [formattedPrimary, formattedSecondary] = await Promise.all([
         formatNumber(primary, {
@@ -521,8 +522,8 @@ export async function findProducts({
         }),
       ]);
 
-      const unitPrimary = mainPrice === 'at' ? 'ATI' : 'WT';
-      const unitSecondary = mainPrice === 'at' ? 'WT' : 'ATI';
+      const unitPrimary = mainPrice === MAIN_PRICE.ATI ? 'ATI' : 'WT';
+      const unitSecondary = mainPrice === MAIN_PRICE.ATI ? 'WT' : 'ATI';
 
       const displayPrimary = `${formattedPrimary} ${unitPrimary}`;
       const displaySecondary = `${formattedSecondary} ${unitSecondary}`;

--- a/changelogs/unreleased/104174.json
+++ b/changelogs/unreleased/104174.json
@@ -1,0 +1,6 @@
+{
+  "title": "Fix mainPrice comparison and add dynamic item pricing",
+  "type": "fix",
+  "description": "Corrected mainPrice comparison from 'ati' to 'at' and updated payload items to apply conditional ATI/WT pricing while creating and requesting an order.",
+  "scope": ["shop"]
+}

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -244,3 +244,11 @@ export const INVOICE_ENTITY_TYPE = {
 
 export const NO_IMAGE_URL = '/images/no-image.png';
 export const DEFAULT_LOGO_URL = `/images/default-logo.png`;
+
+/**
+ * MAIN PRICE
+ */
+export const MAIN_PRICE = {
+  ATI: 'at',
+  WTI: 'wt',
+};

--- a/utils/cart.ts
+++ b/utils/cart.ts
@@ -1,10 +1,10 @@
 // ---- CORE IMPORTS ---- //
-
 import {scale} from '@/utils';
 import {
   DEFAULT_CURRENCY_CODE,
   DEFAULT_CURRENCY_SCALE,
   DEFAULT_CURRENCY_SYMBOL,
+  MAIN_PRICE,
 } from '@/constants';
 import type {
   Cart,
@@ -23,7 +23,7 @@ export function computeTotal({
   workspace?: PortalWorkspace;
   formatNumber?: any;
 }) {
-  let mainPrice: PortalAppConfig['mainPrice'] = 'at';
+  let mainPrice: PortalAppConfig['mainPrice'] = MAIN_PRICE.ATI;
 
   if (workspace?.config?.mainPrice) {
     mainPrice = workspace?.config?.mainPrice;


### PR DESCRIPTION
### What’s Added
Resolved issues in createOrder and requestOrder where incorrect pricing values were sent in the payload, causing conflicts in the generated order or quotation totals.

### Why
The mainPrice configuration was compared using the wrong key ("ati" instead of "at"), resulting in the payload always using ATI pricing. This prevented correct selection between ATI and WT prices, leading to inconsistent and incorrect pricing calculations during order and quotation creation.

### Notes
- Corrected mainPrice comparison from "ati" to "at".
- Introduced isAtiPricing constant to improve readability and maintainability.
- Updated item-level pricing to switch dynamically based on price mode.