### PR TITLE
fix(shop): swap primary and secondary price display ordering in product-view section

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-view/product-view.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/ui/components/product-view/product-view.tsx
@@ -157,12 +157,12 @@ export function ProductView({
             </div>
             {workspace?.config?.displayPrices && !hidePriceAndPurchase && (
               <>
+                <p className="text-xl font-semibold mb-2">
+                  {price.displayPrimary}
+                </p>
                 {price.displayTwoPrices && (
-                  <p className="text-xl font-semibold mb-2">
-                    {price.displaySecondary}
-                  </p>
+                  <p className="text-sm">{price.displaySecondary}</p>
                 )}
-                <p className="text-sm">{price.displayPrimary}</p>
               </>
             )}
             <ProductMetaFieldView productId={product.id} fields={metaFields} />

--- a/changelogs/unreleased/104175.json
+++ b/changelogs/unreleased/104175.json
@@ -1,0 +1,6 @@
+{
+  "title": "Reorder primary and secondary price display",
+  "type": "fix",
+  "description": "Adjusted the rendering order to display the primary price first and the secondary price below it for clearer visual hierarchy in product view section.",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
### What’s Added
Adjusted the display order of product prices to show the primary price first and the secondary price in product view page.

### Why
The previous layout displayed the secondary price above the primary price, causing confusion and inconsistent UX across pricing views.

### Notes
- Rendered displaySecondary conditionally below the primary price when displayTwoPrices is enabled.