### PR TITLE
fix(orders,quotations): correct tax line scaling and formatting 

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/orders/common/orm/orders.ts
+++ b/app/[tenant]/[workspace]/(subapps)/orders/common/orm/orders.ts
@@ -421,6 +421,15 @@ async function processSaleOrderLineList(
         currency: currencySymbol,
         type: 'DECIMAL',
       }),
+      taxLineSet: await Promise.all(
+        line.taxLineSet.map(async (taxLine: any) => ({
+          ...taxLine,
+          value: await formatNumber(taxLine.value, {
+            scale,
+            type: 'DECIMAL',
+          }),
+        })),
+      ),
     })),
   );
 }

--- a/app/[tenant]/[workspace]/(subapps)/quotations/common/orm/quotations.ts
+++ b/app/[tenant]/[workspace]/(subapps)/quotations/common/orm/quotations.ts
@@ -254,6 +254,15 @@ export async function findQuotation({
         currency: currencySymbol,
         type: 'DECIMAL',
       }),
+      taxLineSet: await Promise.all(
+        list.taxLineSet.map(async (taxLine: any) => ({
+          ...taxLine,
+          value: await formatNumber(taxLine.value, {
+            scale,
+            type: 'DECIMAL',
+          }),
+        })),
+      ),
     };
     $saleOrderLineList.push(line);
   }

--- a/app/[tenant]/[workspace]/(subapps)/quotations/common/ui/components/product-card/product-card.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/quotations/common/ui/components/product-card/product-card.tsx
@@ -76,7 +76,7 @@ export const ProductCard = ({
                       {i18n.t('Tax')}
                     </p>
                     <p className="text-base mb-0">
-                      {saleOrder?.taxLineSet[0]?.value} %
+                      {saleOrder?.taxLineSet[0]?.value}%
                     </p>
                   </div>
                   <div className="flex justify-between px-4">

--- a/changelogs/unreleased/104194.json
+++ b/changelogs/unreleased/104194.json
@@ -1,0 +1,6 @@
+{
+  "title": "Fix amount scaling and tax line formatting",
+  "type": "fix",
+  "description": "Applied correct scaling and formatting for totals and taxLineSet values to resolve amount mismatch issues in orders and quotations.",
+  "scope": ["orders", "quotations"]
+}


### PR DESCRIPTION
### What’s Added
Corrected the scaling and formatting of tax line values within order and quotation calculations.

### Why
Tax values were displaying with excessive decimals (e.g., 20.000000% instead of 20.00%), creating a cluttered and confusing display.

### Notes
- Applied proper number scaling based on currency precision and used async formatting for nested taxLineSet values within saleOrderLineList.