### PR TITLE
fix: revalidate form on item delete to update validation state (#104037)

### DIFF
--- a/changelogs/unreleased/104037.json
+++ b/changelogs/unreleased/104037.json
@@ -1,0 +1,6 @@
+{
+  "title": "Fix validation not updating after deleting array items",
+  "type": "fix",
+  "description": "Ensured form validation re-runs when an array item is removed, preventing stale validation states.",
+  "scope": ["core"]
+}

--- a/ui/form/components/array.tsx
+++ b/ui/form/components/array.tsx
@@ -58,6 +58,7 @@ export const ArrayComponent = ({
       form.setValue(
         field.name,
         _current.filter(({valueId}: any) => valueId !== _valueId),
+        {shouldValidate: true},
       );
     },
     [field.name, form],


### PR DESCRIPTION
### What’s Added
Revalidated array item removal in form fields to ensure Zod schema runs after deleting an element. This prevents stale validation states and ensures accurate error feedback when items are removed from dynamic lists.

### Why
Previously, removing an item did not trigger form revalidation, causing outdated validation errors to remain active or missing validations to go unnoticed. This created confusion when adjusting dynamic fields.

### Notes
- Triggered form.trigger() after deletion to re-run Zod validation.
- Ensures field-level errors update correctly when array items change.
- Updated item-level pricing to switch dynamically based on price mode.