### PR TITLE
feat: include paidAmount in order payload with fallback to total when advance payment is not applicable 

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/cart/(protected)/checkout/action.ts
@@ -146,13 +146,15 @@ async function createOrder({
     const payInAdvance = workspace.config?.payInAdvance;
     const advancePaymentPercentage = workspace.config?.advancePaymentPercentage;
 
-    let expectedAmount;
+    let paidAmount;
     if (payInAdvance && Number(advancePaymentPercentage) > 0) {
-      expectedAmount = calculateAdvanceAmount({
+      paidAmount = calculateAdvanceAmount({
         amount: Number(total),
         percentage: Number(advancePaymentPercentage),
         payInAdvance,
       }).toString();
+    } else {
+      paidAmount = Number(total).toString();
     }
 
     const isAtiPricing = workspace?.config?.mainPrice === MAIN_PRICE.ATI;
@@ -177,7 +179,7 @@ async function createOrder({
       workspaceId: workspace.id,
       invocingPartnerAddressId: invoicingAddress,
       deliveryPartnerAddressId: deliveryAddress,
-      ...(expectedAmount ? {paidAmount: expectedAmount} : {}),
+      paidAmount,
     };
 
     const res = await axios.post(ws, payload, {

--- a/changelogs/unreleased/104202.json
+++ b/changelogs/unreleased/104202.json
@@ -1,0 +1,6 @@
+{
+  "title": "Always include paidAmount in payload",
+  "type": "fix",
+  "description": "Updated shop order invoice payload to always include paidAmount, defaulting to the full total when no advance payment percentage is applied.",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
### What’s Added
paidAmount is now always included in the invoice payload — whether the customer pays in advance or pays the full amount upfront. This prevents invoices from being marked as unpaid when the full payment is already collected.

### Why
Previously, paidAmount was only set when an advance payment was used. For full-payment orders, it was missing from the payload, which made invoices appear unpaid even though the customer had already paid.

### Notes
- Renamed expectedAmount to paidAmount for clarity and consistency with payment semantics.
- Added fallback logic to ensure paidAmount = total when no advance percentage applies.