### PR TITLE
Extend Stripe bank transfer support with automatic intent management and balance deduction

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/invoices/common/actions/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/invoices/common/actions/index.ts
@@ -23,18 +23,20 @@ import {
   createStripeOrder,
   findStripeOrder,
   findStripePaymentIntent,
+  cancelStripePaymentIntent,
+  cancelInvalidPendingBankTransfers,
 } from '@/payment/stripe/actions';
-import {
-  findPaymentContext,
-  markPaymentAsCancelled,
-  markPaymentAsProcessed,
-} from '@/payment/common/orm';
+import {findPaymentContext, markPaymentAsProcessed} from '@/payment/common/orm';
 import {PartnerKey, PaymentOption} from '@/types';
 import {getWhereClauseForEntity} from '@/utils/filters';
 import {isPaymentOptionAvailable} from '@/utils/payment';
-import {stripe} from '@/lib/core/payment/stripe';
 import {formatNumber} from '@/lib/core/locale/server/formatters';
 import {PAYMENT_SOURCE, PAYMENT_TYPE} from '@/lib/core/payment/common/type';
+import {
+  BANK_TRANSFER_STATUS,
+  STRIPE_CANCELLATION_REASONS,
+} from '@/lib/core/payment/stripe/constants';
+import {scale} from '@/utils';
 
 // ---- LOCAL IMPORTS ---- //
 import {
@@ -44,6 +46,11 @@ import {
 import {findInvoice} from '@/subapps/invoices/common/orm/invoices';
 import {validatePaymentData} from '@/subapps/invoices/common/utils/validations';
 import {updateInvoice} from '@/subapps/invoices/common/service';
+
+const normalizeAmount = (
+  value: string | number,
+  decimals = DEFAULT_CURRENCY_SCALE,
+) => Number(scale(Number(value), decimals));
 
 export async function paypalCreateOrder({
   invoice,
@@ -239,7 +246,10 @@ export async function paypalCaptureOrder({
       };
     }
 
-    const remainingAmount = Number($invoice.amountRemaining?.value || 0);
+    const remainingAmount = normalizeAmount(
+      $invoice.amountRemaining.value,
+      $invoice.currency.numberOfDecimals,
+    );
 
     const isPartialPayment =
       workspace?.config?.canPayInvoice === INVOICE_PAYMENT_OPTIONS.PARTIAL;
@@ -341,7 +351,11 @@ export async function createStripeCheckoutSession({
         id: payer?.id!,
         email: payer?.emailAddress?.address!,
       },
-      context: {id: invoice.id, paymentType: PAYMENT_TYPE.CARD},
+      context: {
+        id: invoice.id,
+        paymentType: PAYMENT_TYPE.CARD,
+        source: PAYMENT_SOURCE.INVOICES,
+      },
       name: await t('Invoice Checkout'),
       amount: Number($amount),
       currency: currencyCode,
@@ -477,7 +491,10 @@ export async function validateStripePayment({
       return {error: true, message: await t('Invalid invoice!')};
     }
 
-    const remainingAmount = Number($invoice.amountRemaining?.value || 0);
+    const remainingAmount = normalizeAmount(
+      $invoice.amountRemaining.value,
+      $invoice.currency.numberOfDecimals,
+    );
 
     const isPartialPayment =
       workspace?.config?.canPayInvoice === INVOICE_PAYMENT_OPTIONS.PARTIAL;
@@ -515,6 +532,30 @@ export async function validateStripePayment({
       version: context.version,
       tenantId,
     });
+
+    const isFullyPaid = purchaseAmount === remainingAmount;
+    const invoiceType = isFullyPaid ? INVOICE.PAID : INVOICE.UNPAID;
+
+    const updatedInvoice = await findInvoice({
+      id: $invoice.id,
+      params: {where: invoicesWhereClause},
+      workspaceURL,
+      tenantId,
+      type: invoiceType,
+    });
+
+    const updatedAmountRemaining = normalizeAmount(
+      updatedInvoice.amountRemaining.value,
+      updatedInvoice.currency.numberOfDecimals,
+    );
+
+    // Cancel all pending bank transfer intents that are now invalid
+    await cancelInvalidPendingBankTransfers({
+      tenantId,
+      sourceId: updatedInvoice.id,
+      amountRemaining: updatedAmountRemaining,
+    });
+
     revalidatePath(invalidatePath);
     return {success: true, data: $invoice};
   } catch (error) {
@@ -599,7 +640,12 @@ export async function createStripeBankTransferIntent({
       currency: currencyCode,
       countryCode: country.alpha2Code,
     });
-    return {success: true, data: {...result, formattedAmount}};
+    const data =
+      result.status === BANK_TRANSFER_STATUS.PAID
+        ? result
+        : {...result, formattedAmount};
+
+    return {success: true, data};
   } catch (error) {
     console.error('Error creating stripe bank transfer payment intent:', error);
 
@@ -740,14 +786,10 @@ export async function cancelStripeBankTransferPaymentIntent({
       return {error: true, message: await t('Invalid invoice!')};
     }
 
-    await markPaymentAsCancelled({
-      contextId: paymentContext.id,
-      version: paymentContext.version,
+    await cancelStripePaymentIntent({
+      id,
+      cancellationReason: STRIPE_CANCELLATION_REASONS.REQUESTED_BY_CUSTOMER,
       tenantId,
-    });
-
-    await stripe.paymentIntents.cancel(id, {
-      cancellation_reason: 'requested_by_customer',
     });
 
     revalidatePath(
@@ -952,7 +994,10 @@ export async function validatePayboxPayment({
       return {error: true, message: await t('Invalid invoice!')};
     }
 
-    const remainingAmount = Number($invoice.amountRemaining?.value || 0);
+    const remainingAmount = normalizeAmount(
+      $invoice.amountRemaining.value,
+      $invoice.currency.numberOfDecimals,
+    );
 
     const isPartialPayment =
       workspace?.config?.canPayInvoice === INVOICE_PAYMENT_OPTIONS.PARTIAL;

--- a/app/[tenant]/[workspace]/(subapps)/invoices/common/orm/invoices.ts
+++ b/app/[tenant]/[workspace]/(subapps)/invoices/common/orm/invoices.ts
@@ -10,7 +10,7 @@ import {
 import {clone, getPageInfo, getSkipInfo} from '@/utils';
 import {formatNumber} from '@/locale/server/formatters';
 import type {Partner, PortalWorkspace} from '@/types';
-import {CONTEXT_STATUS} from '@/lib/core/payment/common/orm';
+import {findPendingStripeBankTransfers} from '@/lib/core/payment/common/orm';
 import {buildPendingStripeBankTransferIntents} from '@/lib/core/payment/stripe/service';
 
 // ---- LOCAL IMPORTS ---- //
@@ -224,7 +224,7 @@ export const findInvoice = async ({
   }
 
   const pendingStripeBankTransferPayments =
-    await findPendingStripeBankTransfers({tenantId, invoiceId: invoice.id});
+    await findPendingStripeBankTransfers({tenantId, id: invoice.id});
 
   const resolved = await Promise.all(
     pendingStripeBankTransferPayments?.map(async ctx => ({
@@ -272,31 +272,3 @@ export const findInvoice = async ({
     pendingStripeBankTransferIntents,
   };
 };
-
-async function findPendingStripeBankTransfers({
-  tenantId,
-  invoiceId,
-}: {
-  tenantId: Tenant['id'];
-  invoiceId: Invoice['id'];
-}) {
-  if (!invoiceId) return null;
-
-  const client = await manager.getClient(tenantId);
-
-  const result = await client.paymentContext.find({
-    where: {
-      mode: 'stripe',
-      status: CONTEXT_STATUS.pending,
-      AND: [
-        {data: {path: 'id', eq: invoiceId}},
-        {data: {path: 'paymentType', eq: 'bank_transfer'}},
-        {data: {path: 'paymentIntent', ne: null}},
-      ],
-    },
-    select: {data: true, createdOn: true},
-    orderBy: {createdOn: 'DESC'},
-  });
-
-  return result;
-}

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -13,9 +13,14 @@ import {
 import {PaymentOption} from '@/types';
 import {PAYMENT_SOURCE} from '@/lib/core/payment/common/type';
 import {getAmountFromStripe} from '@/utils/stripe';
+import {manager} from '@/tenant';
+import {scale} from '@/utils';
+import {DEFAULT_CURRENCY_SCALE} from '@/constants';
 
 // --- LOCAL IMPORTS ---- //
 import {updateInvoice} from '@/subapps/invoices/common/service';
+import {cancelInvalidPendingBankTransfers} from '@/lib/core/payment/stripe/actions';
+import {STRIPE_PAYMENT_METHOD_TYPE} from '@/lib/core/payment/stripe/constants';
 
 export const STRIPE_EVENTS = {
   PAYMENT_INTENT_SUCCEEDED: 'payment_intent.succeeded',
@@ -82,6 +87,7 @@ export async function POST(req: Request) {
           id: contextId,
           tenantId,
           mode: PaymentOption.stripe,
+          ignoreExpiration: true,
         });
 
         if (!paymentContext) {
@@ -111,16 +117,26 @@ export async function POST(req: Request) {
           paymentIntent.currency,
         );
 
+        const client = await manager.getClient(tenantId);
+
         switch (source) {
           case PAYMENT_SOURCE.INVOICES: {
-            const result = await updateInvoice({
+            const paymentMethodType = paymentIntent.payment_method_types?.[0];
+
+            // Only handle bank transfers
+            if (
+              paymentMethodType !== STRIPE_PAYMENT_METHOD_TYPE.CUSTOMER_BALANCE
+            ) {
+              break;
+            }
+
+            const updateResult = await updateInvoice({
               tenantId,
               amount: paidAmount,
               invoiceId: sourceId,
             });
-
-            if (result?.error) {
-              console.error('Invoice update failed: ', result.error);
+            if (updateResult?.error) {
+              console.error('Invoice update failed:', updateResult.error);
               break;
             }
 
@@ -128,6 +144,35 @@ export async function POST(req: Request) {
               contextId: paymentContext.id,
               version: paymentContext.version,
               tenantId,
+            });
+
+            const invoice = await client.aOSInvoice.findOne({
+              where: {id: sourceId},
+              select: {
+                id: true,
+                amountRemaining: true,
+                currency: {
+                  numberOfDecimals: true,
+                },
+              },
+            });
+
+            if (!invoice) {
+              console.error('Invoice not found:', sourceId);
+              break;
+            }
+
+            const amountRemaining = Number(
+              scale(
+                Number(invoice.amountRemaining),
+                invoice?.currency.numberOfDecimals ?? DEFAULT_CURRENCY_SCALE,
+              ),
+            );
+
+            await cancelInvalidPendingBankTransfers({
+              tenantId,
+              sourceId: invoice.id,
+              amountRemaining,
             });
 
             break;

--- a/changelogs/unreleased/105908.json
+++ b/changelogs/unreleased/105908.json
@@ -1,0 +1,6 @@
+{
+  "title": "Extend bank-transfer support",
+  "type": "feat",
+  "description": "Added automatic cleanup of pending bank transfer intents and customer balance deduction.",
+  "scope": ["core", "invoices"]
+}

--- a/lib/core/payment/common/orm.ts
+++ b/lib/core/payment/common/orm.ts
@@ -1,7 +1,7 @@
 // ---- CORE IMPORTS ---- //
 import {PaymentOption} from '@/types';
 import {manager, type Tenant} from '@/tenant';
-import type {PaymentContext} from './type';
+import {PAYMENT_TYPE, type PaymentContext} from './type';
 
 export const CONTEXT_STATUS = {
   pending: 'pending',
@@ -184,4 +184,32 @@ async function updatePaymentStatus({
     },
     select: {id: true},
   });
+}
+
+export async function findPendingStripeBankTransfers({
+  tenantId,
+  id,
+}: {
+  tenantId: Tenant['id'];
+  id: string;
+}) {
+  if (!id || !tenantId) return null;
+
+  const client = await manager.getClient(tenantId);
+
+  const result = await client.paymentContext.find({
+    where: {
+      mode: 'stripe',
+      status: CONTEXT_STATUS.pending,
+      AND: [
+        {data: {path: 'id', eq: id}},
+        {data: {path: 'paymentType', eq: PAYMENT_TYPE.BANK_TRANSFER}},
+        {data: {path: 'paymentIntent', ne: null}},
+      ],
+    },
+    select: {data: true, createdOn: true},
+    orderBy: {createdOn: 'DESC'},
+  });
+
+  return result;
 }

--- a/lib/core/payment/stripe/actions.ts
+++ b/lib/core/payment/stripe/actions.ts
@@ -1,5 +1,6 @@
 import Stripe from 'stripe';
 
+// ---- CORE IMPORTS ---- //
 import {stripe} from '.';
 import {DEFAULT_CURRENCY_CODE} from '@/constants';
 import {formatAmountForStripe, getAmountFromStripe} from '@/utils/stripe';
@@ -20,13 +21,13 @@ import {
   type PaymentOrder,
 } from '@/lib/core/payment/common/type';
 import {getBankDetailsFromInstructions, getBankTransferConfig} from './utils';
-import type {CountryCode} from './utils';
 import type {BankTransferIntentResult} from '@/ui/components/payment/types';
 import {
   BANK_TRANSFER_STATUS,
   PAYMENT_INTENT_STATUS,
   STRIPE_CANCELLATION_REASONS,
 } from './constants';
+import {CountryCode} from './types';
 
 async function getOrCreateStripeCustomer(
   email: string,

--- a/lib/core/payment/stripe/actions.ts
+++ b/lib/core/payment/stripe/actions.ts
@@ -8,6 +8,10 @@ import {
   createPaymentContext,
   updatePaymentContextData,
   markPaymentAsFailed,
+  markPaymentAsCancelled,
+  CONTEXT_STATUS,
+  findPendingStripeBankTransfers,
+  markPaymentAsProcessed,
 } from '@/lib/core/payment/common/orm';
 import {PaymentOption} from '@/types';
 import type {Tenant} from '@/tenant';
@@ -17,6 +21,12 @@ import {
 } from '@/lib/core/payment/common/type';
 import {getBankDetailsFromInstructions, getBankTransferConfig} from './utils';
 import type {CountryCode} from './utils';
+import type {BankTransferIntentResult} from '@/ui/components/payment/types';
+import {
+  BANK_TRANSFER_STATUS,
+  PAYMENT_INTENT_STATUS,
+  STRIPE_CANCELLATION_REASONS,
+} from './constants';
 
 async function getOrCreateStripeCustomer(
   email: string,
@@ -91,6 +101,9 @@ export async function createStripeOrder({
         client_reference_id: customer?.id,
         customer_email: customer?.email,
         metadata: {context_id: contextId},
+        payment_intent_data: {
+          metadata: {context_id: contextId, tenant_id: tenantId},
+        },
         line_items: [
           {
             quantity: 1,
@@ -190,7 +203,7 @@ export async function createStripePaymentIntent({
   amount: number;
   context: PaymentContextData;
   countryCode: CountryCode;
-}) {
+}): Promise<BankTransferIntentResult> {
   if (!(tenantId && amount && customer?.email && currency && countryCode)) {
     throw new Error(
       'Name, amount, customer, currency and Country code are required',
@@ -245,8 +258,7 @@ export async function createStripePaymentIntent({
         version: paymentContext.version,
         tenantId,
       });
-
-      return;
+      throw new Error('Payment confirmation failed');
     }
 
     // Attach PaymentIntent to the payment context
@@ -260,27 +272,45 @@ export async function createStripePaymentIntent({
       },
     });
 
-    // Extract bank details from the confirmed intent
-    let bankDetails = null;
-    let paymentReference = confirmedIntent.id;
+    // Payment succeeded immediately because the amount was covered by the customer's balance
+    if (confirmedIntent.status === PAYMENT_INTENT_STATUS.SUCCEEDED) {
+      await markPaymentAsProcessed({
+        contextId: paymentContext.id,
+        version: paymentContext.version,
+        tenantId,
+      });
+      return {
+        status: BANK_TRANSFER_STATUS.PAID,
+        id: confirmedIntent.id,
+      } satisfies BankTransferIntentResult;
+    }
 
+    // Extract bank details from the confirmed intent
     if (
       confirmedIntent.next_action?.type === 'display_bank_transfer_instructions'
     ) {
       const instructions =
         confirmedIntent.next_action.display_bank_transfer_instructions;
 
-      paymentReference = instructions?.reference || confirmedIntent.id;
-      bankDetails = getBankDetailsFromInstructions(instructions);
-    }
+      const paymentReference = instructions?.reference || confirmedIntent.id;
 
-    return {
-      id: confirmedIntent.id,
-      amount: confirmedIntent.amount,
-      currency: confirmedIntent.currency,
-      reference: paymentReference,
-      bankDetails,
-    };
+      const bankDetails = getBankDetailsFromInstructions(instructions);
+      if (!bankDetails) {
+        throw new Error('Failed to extract bank transfer details');
+      }
+
+      return {
+        status: BANK_TRANSFER_STATUS.PENDING,
+        id: confirmedIntent.id,
+        amount: confirmedIntent.amount,
+        currency: confirmedIntent.currency,
+        reference: paymentReference,
+        bankDetails,
+      };
+    }
+    throw new Error(
+      `Unexpected PaymentIntent state: ${confirmedIntent.status}`,
+    );
   } catch (error) {
     console.error('Error creating stripe payment intent:', error);
 
@@ -305,4 +335,156 @@ export async function findStripePaymentIntent(paymentIntentId: string) {
     console.error('Error:', error);
     throw new Error('Error retrieving payment intent');
   }
+}
+
+export async function cancelStripePaymentIntent({
+  id,
+  cancellationReason,
+  tenantId,
+}: {
+  id: string;
+  cancellationReason: Stripe.PaymentIntentCancelParams.CancellationReason;
+  tenantId: Tenant['id'];
+}) {
+  if (!id) {
+    throw new Error('Payment intent id is required');
+  }
+
+  if (!tenantId) {
+    throw new Error('Tenant id is required to cancel payment intent');
+  }
+
+  if (!cancellationReason) {
+    throw new Error('Cancellation reason is required');
+  }
+
+  try {
+    const paymentIntent = await findStripePaymentIntent(id);
+    if (paymentIntent.status === PAYMENT_INTENT_STATUS.CANCELED) {
+      throw new Error('Payment intent already canceled');
+    }
+
+    if (paymentIntent.status === PAYMENT_INTENT_STATUS.SUCCEEDED) {
+      throw new Error('Payment intent already succeeded');
+    }
+
+    const contextId = paymentIntent.metadata?.context_id;
+    if (!contextId) {
+      throw new Error('Context id not found in payment intent metadata');
+    }
+
+    const paymentContext = await findPaymentContext({
+      id: contextId,
+      tenantId,
+      mode: PaymentOption.stripe,
+      ignoreExpiration: true,
+    });
+    if (!paymentContext) {
+      throw new Error('Payment context not found');
+    }
+
+    if (paymentContext.status === CONTEXT_STATUS.cancelled) {
+      throw new Error('Payment context already cancelled');
+    }
+
+    const canceledIntent = await stripe.paymentIntents.cancel(
+      id,
+      {
+        cancellation_reason: cancellationReason,
+      },
+      {
+        idempotencyKey: `cancel_pi_${id}_ctx_${paymentContext.id}`,
+      },
+    );
+
+    await markPaymentAsCancelled({
+      contextId: paymentContext.id,
+      version: paymentContext.version,
+      tenantId,
+    });
+
+    return {
+      canceled: true,
+      status: canceledIntent.status,
+    };
+  } catch (error) {
+    console.error('Error cancelling Stripe PaymentIntent', {
+      id,
+      error,
+    });
+
+    throw new Error('Failed to cancel payment intent');
+  }
+}
+
+export async function cancelInvalidPendingBankTransfers({
+  tenantId,
+  sourceId,
+  amountRemaining,
+}: {
+  tenantId: string;
+  sourceId: string;
+  amountRemaining: number;
+}) {
+  if (!sourceId) {
+    throw new Error('Source id is required');
+  }
+
+  if (!tenantId) {
+    throw new Error('Tenant id is required');
+  }
+
+  const pendingContexts = await findPendingStripeBankTransfers({
+    tenantId,
+    id: sourceId,
+  });
+
+  if (!pendingContexts?.length) return;
+
+  const resolvedContexts = await Promise.all(
+    pendingContexts.map(async ctx => ({
+      ...ctx,
+      data: await ctx.data,
+    })),
+  );
+
+  await Promise.allSettled(
+    resolvedContexts.map(async ctx => {
+      const paymentIntentId = ctx.data?.paymentIntent;
+      if (!paymentIntentId) return;
+
+      let paymentIntent;
+      try {
+        paymentIntent = await findStripePaymentIntent(String(paymentIntentId));
+      } catch {
+        return;
+      }
+
+      if (!paymentIntent) {
+        return;
+      }
+
+      const intentAmount = getAmountFromStripe(
+        paymentIntent.amount,
+        paymentIntent.currency,
+      );
+
+      const shouldCancel =
+        amountRemaining === 0 ||
+        (amountRemaining > 0 && intentAmount > amountRemaining);
+
+      if (!shouldCancel) return;
+
+      const cancellationReason =
+        amountRemaining === 0
+          ? STRIPE_CANCELLATION_REASONS.DUPLICATE
+          : STRIPE_CANCELLATION_REASONS.REQUESTED_BY_CUSTOMER;
+
+      await cancelStripePaymentIntent({
+        id: String(paymentIntentId),
+        cancellationReason,
+        tenantId,
+      });
+    }),
+  );
 }

--- a/lib/core/payment/stripe/constants.ts
+++ b/lib/core/payment/stripe/constants.ts
@@ -1,0 +1,29 @@
+export const BANK_TRANSFER_STATUS = {
+  PAID: 'paid',
+  PENDING: 'pending',
+} as const;
+
+export const PAYMENT_INTENT_STATUS = {
+  REQUIRES_PAYMENT_METHOD: 'requires_payment_method',
+  REQUIRES_CONFIRMATION: 'requires_confirmation',
+  REQUIRES_ACTION: 'requires_action',
+  PROCESSING: 'processing',
+  SUCCEEDED: 'succeeded',
+  CANCELED: 'canceled',
+} as const;
+
+export const STRIPE_CANCELLATION_REASONS = {
+  // Customer started the payment but never completed it
+  ABANDONED: 'abandoned',
+  // Payment was created twice for the same order or invoice
+  DUPLICATE: 'duplicate',
+  // Payment was flagged as suspicious or potentially fraudulent
+  FRAUDULENT: 'fraudulent',
+  // Customer explicitly requested to cancel the payment
+  REQUESTED_BY_CUSTOMER: 'requested_by_customer',
+} as const;
+
+export const STRIPE_PAYMENT_METHOD_TYPE = {
+  CARD: 'card',
+  CUSTOMER_BALANCE: 'customer_balance',
+} as const;

--- a/lib/core/payment/stripe/constants.ts
+++ b/lib/core/payment/stripe/constants.ts
@@ -1,6 +1,24 @@
+// ---- CORE IMPORTS ---- //
+import {BankTransferCurrency, BankTransferType, CountryCode} from './types';
+
 export const BANK_TRANSFER_STATUS = {
   PAID: 'paid',
   PENDING: 'pending',
+} as const;
+
+export const BANK_TRANSFER_TYPE = {
+  EU: 'eu_bank_transfer',
+  US: 'us_bank_transfer',
+} as const;
+
+export const BANK_TRANSFER_CURRENCY = {
+  EUR: 'eur',
+  USD: 'usd',
+} as const;
+
+export const BANK_ACCOUNT_TYPE = {
+  IBAN: 'iban',
+  ABA: 'aba',
 } as const;
 
 export const PAYMENT_INTENT_STATUS = {
@@ -27,3 +45,42 @@ export const STRIPE_PAYMENT_METHOD_TYPE = {
   CARD: 'card',
   CUSTOMER_BALANCE: 'customer_balance',
 } as const;
+
+export const BANK_TRANSFER_CONFIGS: Record<
+  BankTransferCurrency,
+  {
+    type: BankTransferType;
+    recommendedCountries: CountryCode[];
+    default: CountryCode;
+  }
+> = {
+  [BANK_TRANSFER_CURRENCY.EUR]: {
+    type: BANK_TRANSFER_TYPE.EU,
+    recommendedCountries: ['FR', 'DE', 'ES', 'IT', 'NL', 'BE'],
+    default: 'FR',
+  },
+  [BANK_TRANSFER_CURRENCY.USD]: {
+    type: BANK_TRANSFER_TYPE.US,
+    recommendedCountries: ['US'],
+    default: 'US',
+  },
+};
+
+export const COUNTRY_TO_BANK_TRANSFER: Record<
+  CountryCode,
+  {currency: BankTransferCurrency; type: BankTransferType}
+> = Object.entries(BANK_TRANSFER_CONFIGS).reduce(
+  (acc, [currency, config]) => {
+    config.recommendedCountries.forEach(country => {
+      acc[country] = {
+        currency: currency as BankTransferCurrency,
+        type: config.type,
+      };
+    });
+    return acc;
+  },
+  {} as Record<
+    CountryCode,
+    {currency: BankTransferCurrency; type: BankTransferType}
+  >,
+);

--- a/lib/core/payment/stripe/types.ts
+++ b/lib/core/payment/stripe/types.ts
@@ -1,4 +1,32 @@
-import {BANK_TRANSFER_STATUS} from '@/payment/stripe/constants';
+// ---- CORE IMPORTS ---- //
+import {
+  BANK_ACCOUNT_TYPE,
+  BANK_TRANSFER_CURRENCY,
+  BANK_TRANSFER_STATUS,
+  BANK_TRANSFER_TYPE,
+} from '@/payment/stripe/constants';
 
 export type BankTransferStatus =
   (typeof BANK_TRANSFER_STATUS)[keyof typeof BANK_TRANSFER_STATUS];
+
+export type BankTransferType =
+  (typeof BANK_TRANSFER_TYPE)[keyof typeof BANK_TRANSFER_TYPE];
+
+export type CountryCode = 'FR' | 'DE' | 'ES' | 'IT' | 'NL' | 'BE' | 'US';
+
+export type BankAccountType =
+  (typeof BANK_ACCOUNT_TYPE)[keyof typeof BANK_ACCOUNT_TYPE];
+
+export type StripeBankTransfer =
+  | {
+      type: typeof BANK_TRANSFER_TYPE.EU;
+      eu_bank_transfer: {
+        country: CountryCode;
+      };
+    }
+  | {
+      type: typeof BANK_TRANSFER_TYPE.US;
+    };
+
+export type BankTransferCurrency =
+  (typeof BANK_TRANSFER_CURRENCY)[keyof typeof BANK_TRANSFER_CURRENCY];

--- a/lib/core/payment/stripe/types.ts
+++ b/lib/core/payment/stripe/types.ts
@@ -1,0 +1,4 @@
+import {BANK_TRANSFER_STATUS} from '@/payment/stripe/constants';
+
+export type BankTransferStatus =
+  (typeof BANK_TRANSFER_STATUS)[keyof typeof BANK_TRANSFER_STATUS];

--- a/lib/core/payment/stripe/utils.ts
+++ b/lib/core/payment/stripe/utils.ts
@@ -3,82 +3,14 @@ import Stripe from 'stripe';
 // ---- CORE IMPORTS ---- //
 import {getCountryName} from '@/utils/country';
 import {NormalizedBankDetails} from '@/ui/components/payment/types';
-
-export const BANK_TRANSFER_TYPE = {
-  EU: 'eu_bank_transfer',
-  US: 'us_bank_transfer',
-} as const;
-
-export type BankTransferType =
-  (typeof BANK_TRANSFER_TYPE)[keyof typeof BANK_TRANSFER_TYPE];
-
-export const BANK_TRANSFER_CURRENCY = {
-  EUR: 'eur',
-  USD: 'usd',
-} as const;
-
-export type BankTransferCurrency =
-  (typeof BANK_TRANSFER_CURRENCY)[keyof typeof BANK_TRANSFER_CURRENCY];
-
-export const BANK_ACCOUNT_TYPE = {
-  IBAN: 'iban',
-  ABA: 'aba',
-} as const;
-
-export type BankAccountType =
-  (typeof BANK_ACCOUNT_TYPE)[keyof typeof BANK_ACCOUNT_TYPE];
-
-export type CountryCode = 'FR' | 'DE' | 'ES' | 'IT' | 'NL' | 'BE' | 'US';
-
-type StripeBankTransfer =
-  | {
-      type: typeof BANK_TRANSFER_TYPE.EU;
-      eu_bank_transfer: {
-        country: CountryCode;
-      };
-    }
-  | {
-      type: typeof BANK_TRANSFER_TYPE.US;
-    };
-
-const BANK_TRANSFER_CONFIGS: Record<
-  BankTransferCurrency,
-  {
-    type: BankTransferType;
-    recommendedCountries: CountryCode[];
-    default: CountryCode;
-  }
-> = {
-  [BANK_TRANSFER_CURRENCY.EUR]: {
-    type: BANK_TRANSFER_TYPE.EU,
-    recommendedCountries: ['FR', 'DE', 'ES', 'IT', 'NL', 'BE'],
-    default: 'FR',
-  },
-  [BANK_TRANSFER_CURRENCY.USD]: {
-    type: BANK_TRANSFER_TYPE.US,
-    recommendedCountries: ['US'],
-    default: 'US',
-  },
-};
-
-const COUNTRY_TO_BANK_TRANSFER: Record<
-  CountryCode,
-  {currency: BankTransferCurrency; type: BankTransferType}
-> = Object.entries(BANK_TRANSFER_CONFIGS).reduce(
-  (acc, [currency, config]) => {
-    config.recommendedCountries.forEach(country => {
-      acc[country] = {
-        currency: currency as BankTransferCurrency,
-        type: config.type,
-      };
-    });
-    return acc;
-  },
-  {} as Record<
-    CountryCode,
-    {currency: BankTransferCurrency; type: BankTransferType}
-  >,
-);
+import {BankTransferCurrency, CountryCode, StripeBankTransfer} from './types';
+import {
+  BANK_ACCOUNT_TYPE,
+  BANK_TRANSFER_CONFIGS,
+  BANK_TRANSFER_CURRENCY,
+  BANK_TRANSFER_TYPE,
+  COUNTRY_TO_BANK_TRANSFER,
+} from './constants';
 
 export function getBankTransferConfig(
   currency: string,

--- a/lib/core/payment/stripe/utils.ts
+++ b/lib/core/payment/stripe/utils.ts
@@ -150,7 +150,6 @@ export function getBankDetailsFromInstructions(
         swiftCode: iban.bic ?? undefined,
         accountHolderName: iban.account_holder_name ?? undefined,
         country: getCountryName(iban.country),
-        bankName: iban.bank_name ?? undefined,
         bankAddress: iban.bank_address ?? undefined,
         accountHolderAddress: iban.account_holder_address ?? undefined,
       };

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -837,5 +837,12 @@
   "No upcoming events": "No upcoming events",
   "View all": "View all",
   "Back to Directory": "Back to Directory",
-  "Contact already exists with another partner.": "Contact already exists with another partner."
+  "Contact already exists with another partner.": "Contact already exists with another partner.",
+  "Confirm Bank Transfer": "Confirm Bank Transfer",
+  "Bank transfers may immediately use your existing Stripe balance.": "Bank transfers may immediately use your existing Stripe balance.",
+  "If you already have sufficient balance, this payment will be completed instantly and funds will be deducted.": "If you already have sufficient balance, this payment will be completed instantly and funds will be deducted.",
+  "Bank details are currently unavailable": "Bank details are currently unavailable",
+  "We could not load the bank transfer details at this time.": "We could not load the bank transfer details at this time.",
+  "Please try again later or contact support if the issue persists.": "Please try again later or contact support if the issue persists.",
+  "Payment completed successfully": "Payment completed successfully"
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -837,5 +837,12 @@
   "No upcoming events": "Aucun événement à venir",
   "View all": "Voir tout",
   "Back to Directory": "Retour à l’annuaire",
-  "Contact already exists with another partner.": "Le contact existe déjà avec un autre partenaire."
+  "Contact already exists with another partner.": "Le contact existe déjà avec un autre partenaire.",
+  "Confirm Bank Transfer": "Confirmer le virement bancaire",
+  "Bank transfers may immediately use your existing Stripe balance.": "Les virements bancaires peuvent utiliser immédiatement votre solde Stripe existant.",
+  "If you already have sufficient balance, this payment will be completed instantly and funds will be deducted.": "Si votre solde est suffisant, ce paiement sera effectué instantanément et les fonds seront débités.",
+  "Bank details are currently unavailable": "Les coordonnées bancaires ne sont pas disponibles pour le moment.",
+  "We could not load the bank transfer details at this time.": "Nous n'avons pas pu charger les détails du virement bancaire pour le moment.",
+  "Please try again later or contact support if the issue persists.": "Veuillez réessayer plus tard ou contacter l'assistance si le problème persiste.",
+  "Payment completed successfully": "Paiement effectué avec succès"
 }

--- a/ui/components/payment/stripe/bank-transfer-confirmation-dialog.tsx
+++ b/ui/components/payment/stripe/bank-transfer-confirmation-dialog.tsx
@@ -1,0 +1,66 @@
+// ---- CORE IMPORTS ---- //
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Button,
+} from '@/ui/components';
+import {i18n} from '@/lib/core/locale';
+
+type BankTransferConfirmDialogProps = {
+  open: boolean;
+  isLoading: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+};
+
+export function BankTransferConfirmDialog({
+  open,
+  isLoading,
+  onOpenChange,
+  onConfirm,
+  onCancel,
+}: BankTransferConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{i18n.t('Confirm Bank Transfer')}</DialogTitle>
+
+          <DialogDescription asChild>
+            <div className="space-y-3">
+              <p>
+                {i18n.t(
+                  'Bank transfers may immediately use your existing Stripe balance.',
+                )}
+              </p>
+
+              <p className="text-sm text-gray-600">
+                {i18n.t(
+                  'If you already have sufficient balance, this payment will be completed instantly and funds will be deducted.',
+                )}
+              </p>
+
+              <p className="text-sm text-gray-600 font-medium">
+                {i18n.t('This action cannot be undone.')}
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex justify-end gap-3 mt-6">
+          <Button variant="outline" disabled={isLoading} onClick={onCancel}>
+            {i18n.t('Cancel')}
+          </Button>
+
+          <Button disabled={isLoading} onClick={onConfirm}>
+            {i18n.t('Continue')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/components/payment/stripe/bank-transfer-details.tsx
+++ b/ui/components/payment/stripe/bank-transfer-details.tsx
@@ -111,6 +111,43 @@ export function BankTransferDetails({
   const showAddresses =
     details.bankDetails.bankAddress || details.bankDetails.accountHolderAddress;
 
+  if (!details?.bankDetails) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{i18n.t('Bank Transfer Payment')}</DialogTitle>
+            <DialogDescription>
+              ⚠️ {i18n.t('Bank details are currently unavailable')}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3 text-sm text-muted-foreground">
+            <p>
+              {i18n.t(
+                'We could not load the bank transfer details at this time.',
+              )}
+            </p>
+            <p>
+              {i18n.t(
+                'Please try again later or contact support if the issue persists.',
+              )}
+            </p>
+          </div>
+
+          <footer className="flex pt-6 border-t border-border mt-4">
+            <Button
+              onClick={() => onOpenChange(false)}
+              variant="outline"
+              className="flex-1">
+              {i18n.t('Close')}
+            </Button>
+          </footer>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[90vh] flex flex-col">

--- a/ui/components/payment/stripe/bank-transfer-details.tsx
+++ b/ui/components/payment/stripe/bank-transfer-details.tsx
@@ -22,7 +22,7 @@ import {
   BankAddress,
   NormalizedBankDetails,
 } from '@/ui/components/payment/types';
-import {BANK_ACCOUNT_TYPE} from '@/lib/core/payment/stripe/utils';
+import {BANK_ACCOUNT_TYPE} from '@/lib/core/payment/stripe/constants';
 
 interface BankTransferDetailsProps {
   details: {

--- a/ui/components/payment/stripe/stripe.tsx
+++ b/ui/components/payment/stripe/stripe.tsx
@@ -22,6 +22,8 @@ import type {
 } from '@/ui/components/payment/types';
 import {PaymentOption} from '@/types';
 import {BankTransferDetails} from './bank-transfer-details';
+import {BankTransferConfirmDialog} from './bank-transfer-confirmation-dialog';
+import {BANK_TRANSFER_STATUS} from '@/lib/core/payment/stripe/constants';
 
 export function Stripe({
   disabled,
@@ -42,6 +44,7 @@ export function Stripe({
     useState<BankTransferDetailsType | null>(null);
   const [showBankDetails, setShowBankDetails] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [showBankTransferConfirm, setShowBankTransferConfirm] = useState(false);
 
   const {searchParams} = useSearchParams();
   const validateRef = useRef(false);
@@ -164,8 +167,24 @@ export function Stripe({
         return;
       }
 
-      setBankTransferDetails(result.data);
-      setShowBankDetails(true);
+      const data = result.data;
+
+      // CASE 1: Auto-paid via customer's balance
+      if (data.status === BANK_TRANSFER_STATUS.PAID) {
+        toast({
+          variant: 'success',
+          title: i18n.t('Payment completed successfully'),
+        });
+
+        handleBankDetailsDialogClose();
+        return;
+      }
+
+      // CASE 2: Needs bank transfer
+      if (data.status === BANK_TRANSFER_STATUS.PENDING && data.bankDetails) {
+        setBankTransferDetails(data);
+        setShowBankDetails(true);
+      }
     } catch (err) {
       console.error(err);
       toast({
@@ -175,6 +194,20 @@ export function Stripe({
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleBankTransferDialogOpenChange = (open: boolean) => {
+    if (isLoading) return;
+    setShowBankTransferConfirm(open);
+  };
+
+  const handleBankTransferCancel = () => {
+    setShowBankTransferConfirm(false);
+  };
+
+  const handleBankTransferConfirm = async () => {
+    setShowBankTransferConfirm(false);
+    await handleBankTransferPayment();
   };
 
   const stripeSessionId = searchParams.get('stripe_session_id');
@@ -242,7 +275,9 @@ export function Stripe({
                         ? 'cursor-default bg-gray-50 opacity-75'
                         : 'cursor-pointer hover:bg-gray-50'
                     }`}
-                    onClick={() => !isLoading && handleBankTransferPayment()}>
+                    onClick={() =>
+                      !isLoading && setShowBankTransferConfirm(true)
+                    }>
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex items-center flex-1">
                         <div className="mr-3 text-xl">🏦</div>
@@ -271,6 +306,15 @@ export function Stripe({
           </DialogHeader>
         </DialogContent>
       </Dialog>
+      {showBankTransferConfirm && (
+        <BankTransferConfirmDialog
+          open={showBankTransferConfirm}
+          isLoading={isLoading}
+          onOpenChange={handleBankTransferDialogOpenChange}
+          onCancel={handleBankTransferCancel}
+          onConfirm={handleBankTransferConfirm}
+        />
+      )}
       {showBankDetails && bankTransferDetails && (
         <BankTransferDetails
           open={showBankDetails}

--- a/ui/components/payment/types/index.ts
+++ b/ui/components/payment/types/index.ts
@@ -1,6 +1,6 @@
 // ---- CORE IMPORTS ---- //
 import {BANK_TRANSFER_STATUS} from '@/lib/core/payment/stripe/constants';
-import {BankAccountType} from '@/lib/core/payment/stripe/utils';
+import {BankAccountType} from '@/lib/core/payment/stripe/types';
 import {ErrorResponse, SuccessResponse} from '@/types/action';
 
 export type PaypalProps = {

--- a/ui/components/payment/types/index.ts
+++ b/ui/components/payment/types/index.ts
@@ -1,4 +1,5 @@
 // ---- CORE IMPORTS ---- //
+import {BANK_TRANSFER_STATUS} from '@/lib/core/payment/stripe/constants';
 import {BankAccountType} from '@/lib/core/payment/stripe/utils';
 import {ErrorResponse, SuccessResponse} from '@/types/action';
 
@@ -37,9 +38,24 @@ export type StripeProps = {
   onPaymentSuccess?: () => any;
   skipSuccessToast?: boolean;
   onCreateBankTransferIntent?: () => Promise<
-    ErrorResponse | SuccessResponse<BankTransferDetailsType>
+    ErrorResponse | SuccessResponse<BankTransferIntentResult>
   >;
 };
+
+export type BankTransferIntentResult =
+  | {
+      status: typeof BANK_TRANSFER_STATUS.PAID;
+      id: string;
+    }
+  | ({
+      status: typeof BANK_TRANSFER_STATUS.PENDING;
+    } & {
+      id: string;
+      amount: number;
+      currency: string;
+      reference: string;
+      bankDetails: NormalizedBankDetails;
+    });
 
 export type BankTransferDetailsType = {
   id: string;


### PR DESCRIPTION
### What’s Added
- Implemented automatic cleanup of pending bank transfer payment intents based on invoice payment progress.
- Added logic to adjust or cancel pending bank transfer intents depending on the remaining invoice balance.
- Enabled direct deduction from Stripe customer balance when available during bank transfer payments.

### Why
- Prevents duplicate or excess bank transfer payments
- Improves payment accuracy and invoice reconciliation.
- Enhances user experience by automatically using available customer balance.


### Notes
- Applies to mixed payment scenarios involving both card and bank transfer payments.
- Handles asynchronous bank transfer payment flows safely.
- Maintains consistency between Stripe payment state and invoice pending amounts.