### PR TITLE
fix(stripe): skip payment method dialog when only card payment is available

### DIFF
--- a/changelogs/unreleased/113213.json
+++ b/changelogs/unreleased/113213.json
@@ -1,0 +1,6 @@
+{
+  "title": "Skip payment method dialog when only card payment is available",
+  "type": "fix",
+  "description": "When bank transfer is not configured for an app, clicking 'Pay with Stripe' no longer shows a single-option selection dialog. The card payment flow is now triggered directly.",
+  "scope": ["core"]
+}

--- a/ui/components/payment/stripe/stripe.tsx
+++ b/ui/components/payment/stripe/stripe.tsx
@@ -116,6 +116,11 @@ export function Stripe<TData>({
       }
     }
 
+    if (!isBankTransferEnabled) {
+      await handleCardPayment();
+      return;
+    }
+
     setShowPaymentOptions(true);
   };
 


### PR DESCRIPTION
https://redmine.axelor.com/issues/113213