### PR TITLE
fix(payment): improve HUB PISP webhook handling and align with v1.5 spec

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/invoices/common/actions/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/invoices/common/actions/index.ts
@@ -1442,7 +1442,6 @@ export async function initiatePispPayment({
       name: [$invoice?.partner?.firstName, $invoice?.partner?.name]
         .filter(Boolean)
         .join(' '),
-      email: pispEmail,
     };
     const currencyCode = $invoice?.currency?.code || DEFAULT_CURRENCY_CODE;
     const response = await createHubPispPaymentLink({

--- a/app/api/webhooks/hubpisp/[resourceId]/route.ts
+++ b/app/api/webhooks/hubpisp/[resourceId]/route.ts
@@ -30,7 +30,6 @@ export async function POST(
   const {resourceId} = await params;
 
   let linkData: PaymentLinkStatusResult;
-
   try {
     linkData = await fetchPaymentLinkStatus(resourceId);
   } catch (err) {
@@ -39,8 +38,7 @@ export async function POST(
         resourceId,
         body: err.body,
       });
-
-      // Do NOT fail webhook
+      // Do NOT fail the webhook — BPCE will retry.
       return new NextResponse('OK', {status: 200});
     }
 
@@ -130,12 +128,15 @@ export async function POST(
   }
 
   // Persist paymentRequestResourceId so startup polling can resume it after a server restart.
-  await updatePaymentContextData({
+  const updatedContext = await updatePaymentContextData({
     id: paymentContext.id,
     version: paymentContext.version,
     client,
     context: {...paymentContext.data, paymentRequestResourceId},
   });
+
+  paymentContext.version = updatedContext.version;
+  paymentContext.data = {...paymentContext.data, paymentRequestResourceId};
 
   const localInstrument = paymentContext.data?.localInstrument as
     | HubPispLocalInstrument

--- a/lib/core/payment/common/orm.ts
+++ b/lib/core/payment/common/orm.ts
@@ -117,7 +117,7 @@ export async function updatePaymentContextData({
       data: Promise.resolve(context),
       updatedOn: new Date(),
     },
-    select: {id: true},
+    select: {id: true, version: true},
   });
 
   return result;

--- a/lib/core/payment/hubpisp/actions.ts
+++ b/lib/core/payment/hubpisp/actions.ts
@@ -16,7 +16,7 @@ import {
   HubPispLocalInstrument,
 } from './constants';
 import type {HubPispContextData, PageConsentInfo, PsuInfo} from './types';
-import {pollPaymentLinkStatus} from './pollLink';
+import {scheduleLinkExpiryCheck} from './pollLink';
 
 export async function createHubPispPaymentLink({
   amount,
@@ -94,12 +94,14 @@ export async function createHubPispPaymentLink({
     context: {...context, resourceId},
   });
 
-  pollPaymentLinkStatus({
+  // Link-state changes are driven by the webhook
+  // We only schedule a single expiry backstop check instead of polling GET payment-link.
+  scheduleLinkExpiryCheck({
     resourceId,
     contextId,
     tenantId,
     localInstrument,
-    expireIn: HUBPISP_DEFAULT_EXPIRE_IN,
+    delaySeconds: HUBPISP_DEFAULT_EXPIRE_IN,
   });
 
   return {resourceId, consentHref, contextId};

--- a/lib/core/payment/hubpisp/constants.ts
+++ b/lib/core/payment/hubpisp/constants.ts
@@ -9,13 +9,14 @@ export type HubPispConsentStatus =
   (typeof HUBPISP_CONSENT_STATUS)[keyof typeof HUBPISP_CONSENT_STATUS];
 
 export const HUBPISP_TRANSACTION_STATUS = {
-  ACCP: 'ACCP', // Accepted by creditor agent — non-terminal
-  ACSC: 'ACSC', // Settlement confirmed — terminal, success
-  ACSP: 'ACSP', // Accepted, will execute — non-terminal
-  ACTC: 'ACTC', // Authentication & validation done — non-terminal
-  CANC: 'CANC', // Cancelled — terminal, failure
-  PDNG: 'PDNG', // Pending — non-terminal
-  RJCT: 'RJCT', // Rejected — terminal, failure
+  // Terminal (Final = OUI) — a final outcome has been reached, stop polling.
+  ACSC: 'ACSC', // success — debtor account debited, cannot be cancelled
+  CANC: 'CANC', // failure — cancelled after a cancellation request
+  RJCT: 'RJCT', // failure — payment request rejected
+  // Non-terminal (Final = NON) — keep polling until terminal.
+  ACSP: 'ACSP', // accepted, will execute (cannot be cancelled)
+  ACTC: 'ACTC', // auth + validation done (can still be cancelled)
+  PDNG: 'PDNG', // still being processed; further checks to come
 } as const;
 
 export type HubPispTransactionStatus =

--- a/lib/core/payment/hubpisp/index.ts
+++ b/lib/core/payment/hubpisp/index.ts
@@ -73,7 +73,7 @@ export async function createPaymentLink(
     beneficiary: {
       creditor: {name: beneficiaryName},
       creditorAccount: {iban},
-      creditorAgent: bicFi ? {bic: bicFi} : undefined,
+      creditorAgent: bicFi ? {bicFi} : undefined,
     },
     requestedExecutionDate,
     consentInfo: {

--- a/lib/core/payment/hubpisp/orm.ts
+++ b/lib/core/payment/hubpisp/orm.ts
@@ -115,7 +115,7 @@ export type PendingHubPispStartupContext = {
  * Returns all pending HUB PISP contexts that have a resourceId, used to resume polling on restart.
  * Callers split the result by whether paymentRequestResourceId is set:
  * - set: resume pollPaymentRequestStatus
- * - null: resume pollPaymentLinkStatus
+ * - null: reconcile the link once and re-arm its expiry backstop (no polling loop)
  */
 export async function findAllPendingHubPispContexts({
   client,

--- a/lib/core/payment/hubpisp/poll.ts
+++ b/lib/core/payment/hubpisp/poll.ts
@@ -13,7 +13,7 @@ const activePolls = new Set<string>();
 
 // Polling intervals in milliseconds
 const POLL_INTERVAL_INST = 10_000; // 10s for SCTInst (completes in ~10s)
-const POLL_INTERVAL_SCT = 30_000; // 30s for SCT (can take up to 1 business day)
+const POLL_INTERVAL_SCT = 5 * 60_000; // 5min for SCT (settles in ~1 business day; no need to poll tightly)
 
 // Max polling duration in milliseconds
 const MAX_POLL_DURATION_INST = 2 * 60 * 1000; // 2 minutes for SCTInst

--- a/lib/core/payment/hubpisp/pollLink.ts
+++ b/lib/core/payment/hubpisp/pollLink.ts
@@ -13,188 +13,190 @@ import type {HubPispLocalInstrument} from './constants';
 import {pollPaymentRequestStatus} from './poll';
 import {manager} from '@/tenant';
 
-const POLL_LINK_INTERVAL = 30_000; // 30s
+// Tracks scheduled expiry checks to avoid duplicate timers for the same link.
+const scheduledExpiryChecks = new Set<string>();
 
-// Tracks active payment link polls to prevent duplicate sessions.
-const activePolls = new Set<string>();
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+// Buffer added after the expiry instant so BPCE has flipped the link to EXPIRED.
+const EXPIRY_CHECK_BUFFER_MS = 5_000;
 
 /**
- * Fallback poller for the payment link status.
- * Started fire-and-forget after createPaymentLink so that if the webhook
- * is never triggered, we still detect when the link becomes PROCESSED and
- * can hand off to pollPaymentRequestStatus.
+ * One-shot reconciliation of a payment link (a SINGLE GET, never a loop).
+ * Used as a restart catch-up and the expiry backstop; the webhook is the live driver.
  *
- * The webhook remains the fast path — when it fires first it will store
- * paymentRequestResourceId and start the payment request poll. This poller
- * will then find the context already in a terminal state and exit immediately.
+ *   - PROCESSED          → store paymentRequestResourceId + start the payment request poll
+ *   - EXPIRED            → mark the context expired
+ *   - PENDING / EXECUTED → no-op (BPCE still considers the link valid; expiry is left
+ *                          to BPCE, which pushes EXPIRED via webhook)
  */
-export async function pollPaymentLinkStatus({
+export async function reconcilePaymentLinkStatus({
   resourceId,
   contextId,
   tenantId,
   localInstrument,
-  expireIn,
 }: {
   resourceId: string;
   contextId: string;
   tenantId: string;
   localInstrument?: HubPispLocalInstrument;
-  expireIn: number;
 }): Promise<void> {
-  if (activePolls.has(resourceId)) {
-    console.log('[HUBPISP][POLL_LINK] Poll already active, skipping', {
-      resourceId,
+  const tenant = await manager.getTenant(tenantId);
+  if (!tenant) {
+    console.error('[HUBPISP][RECONCILE_LINK] Tenant not found', {
+      tenantId,
+      contextId,
+    });
+    return;
+  }
+  const {client} = tenant;
+
+  const paymentContext = await findPaymentContext({
+    id: contextId,
+    client,
+    mode: PaymentOption.hubpisp,
+    ignoreExpiration: true,
+  });
+
+  if (!paymentContext) {
+    console.warn('[HUBPISP][RECONCILE_LINK] Payment context not found', {
       contextId,
     });
     return;
   }
 
-  activePolls.add(resourceId);
+  // Webhook already moved it out of pending — nothing to do.
+  if (paymentContext.status !== CONTEXT_STATUS.pending) {
+    return;
+  }
 
-  const deadline = Date.now() + expireIn * 1000;
+  // Webhook already stored the payment request id — the payment request poll owns it.
+  if (paymentContext.data?.paymentRequestResourceId) {
+    return;
+  }
 
-  console.log('[HUBPISP][POLL_LINK] Starting fallback payment link poll', {
-    resourceId,
-    contextId,
-    expireIn,
+  let linkStatusResult: Awaited<ReturnType<typeof getPaymentLinkStatus>>;
+  try {
+    linkStatusResult = await getPaymentLinkStatus(resourceId);
+  } catch (err) {
+    console.error(
+      '[HUBPISP][RECONCILE_LINK] Failed to fetch payment link status',
+      {
+        resourceId,
+        error: (err as Error).message,
+      },
+    );
+    return;
+  }
+
+  if (linkStatusResult.consentStatus === HUBPISP_CONSENT_STATUS.EXPIRED) {
+    console.warn('[HUBPISP][RECONCILE_LINK] Payment link expired', {
+      resourceId,
+    });
+    await markPaymentAsExpired({
+      contextId: paymentContext.id,
+      version: paymentContext.version,
+      client,
+    });
+    return;
+  }
+
+  if (linkStatusResult.consentStatus !== HUBPISP_CONSENT_STATUS.PROCESSED) {
+    // PENDING / EXECUTED — BPCE still considers the link valid, so we don't expire
+    // it on our local clock. BPCE is authoritative for expiry and pushes EXPIRED
+    // via the webhook (this reconcile GET already catches a missed EXPIRED above).
+    return;
+  }
+
+  const paymentRequestResourceId =
+    linkStatusResult.data.paymentRequestResourceId;
+  if (!paymentRequestResourceId) {
+    console.warn(
+      '[HUBPISP][RECONCILE_LINK] Link PROCESSED but missing paymentRequestResourceId',
+      {contextId},
+    );
+    return;
+  }
+
+  console.log(
+    '[HUBPISP][RECONCILE_LINK] Link PROCESSED, handing off to payment request poll',
+    {contextId, paymentRequestResourceId},
+  );
+
+  await updatePaymentContextData({
+    id: paymentContext.id,
+    version: paymentContext.version,
+    client,
+    context: {...paymentContext.data, paymentRequestResourceId},
   });
 
-  try {
-    while (Date.now() < deadline) {
-      await sleep(POLL_LINK_INTERVAL);
+  pollPaymentRequestStatus({
+    paymentRequestResourceId,
+    contextId: paymentContext.id,
+    tenantId,
+    localInstrument,
+  });
+}
 
-      const tenant = await manager.getTenant(tenantId);
-      if (!tenant) {
-        console.error('[HUBPISP][POLL_LINK] Tenant not found, stopping poll', {
-          tenantId,
-          contextId,
-        });
-        return;
-      }
-      const {client} = tenant;
+/**
+ * Schedules a SINGLE expiry check `delaySeconds` from now.
+ *
+ * Why: the BPCE webhook is the primary driver of link state, but a notification can
+ * be missed. Without this, a payment whose EXPIRED/PROCESSED webhook never arrives
+ * would stay `pending` forever (the generic context expiry doesn't apply to HUB PISP).
+ * This timer normally no-ops; it only fires one GET at the link's expiry instant to
+ * resolve such a payment. If BPCE still reports the link valid (PENDING/EXECUTED) we
+ * leave expiry to BPCE. (§4.3.3 recommends keeping such a check, not trusting the
+ * webhook alone.)
+ *
+ * Replaces the old 30s polling loop. In-process timer (single-server / in-memory
+ * model); startup.ts re-arms it for the remaining window after a restart.
+ */
+export function scheduleLinkExpiryCheck({
+  resourceId,
+  contextId,
+  tenantId,
+  localInstrument,
+  delaySeconds,
+}: {
+  resourceId: string;
+  contextId: string;
+  tenantId: string;
+  localInstrument?: HubPispLocalInstrument;
+  delaySeconds: number;
+}): void {
+  if (scheduledExpiryChecks.has(resourceId)) {
+    return;
+  }
+  if (delaySeconds <= 0) {
+    return;
+  }
 
-      const paymentContext = await findPaymentContext({
-        id: contextId,
-        client,
-        mode: PaymentOption.hubpisp,
-        ignoreExpiration: true,
-      });
+  scheduledExpiryChecks.add(resourceId);
 
-      if (!paymentContext) {
-        console.warn(
-          '[HUBPISP][POLL_LINK] Payment context not found, stopping poll',
-          {contextId},
-        );
-        return;
-      }
+  console.log('[HUBPISP][EXPIRY_CHECK] Scheduling expiry backstop', {
+    resourceId,
+    contextId,
+    delaySeconds,
+  });
 
-      // Webhook already handled it — nothing left to do
-      if (paymentContext.status !== CONTEXT_STATUS.pending) {
-        console.log(
-          '[HUBPISP][POLL_LINK] Context no longer pending, stopping poll',
-          {contextId, status: paymentContext.status},
-        );
-        return;
-      }
-
-      // Webhook stored paymentRequestResourceId — payment request poll is running
-      if (paymentContext.data?.paymentRequestResourceId) {
-        console.log(
-          '[HUBPISP][POLL_LINK] paymentRequestResourceId already set, stopping link poll',
-          {contextId},
-        );
-        return;
-      }
-
-      let linkStatusResult: Awaited<ReturnType<typeof getPaymentLinkStatus>>;
-      try {
-        linkStatusResult = await getPaymentLinkStatus(resourceId);
-      } catch (err) {
-        console.error(
-          '[HUBPISP][POLL_LINK] Failed to fetch payment link status',
-          {resourceId, error: (err as Error).message},
-        );
-        continue;
-      }
-
-      if (linkStatusResult.consentStatus === HUBPISP_CONSENT_STATUS.EXPIRED) {
-        console.warn('[HUBPISP][POLL_LINK] Payment link expired', {resourceId});
-        await markPaymentAsExpired({
-          contextId: paymentContext.id,
-          version: paymentContext.version,
-          client,
-        });
-        return;
-      }
-
-      if (linkStatusResult.consentStatus !== HUBPISP_CONSENT_STATUS.PROCESSED) {
-        console.log('[HUBPISP][POLL_LINK] Link not yet processed, continuing', {
-          contextId,
-          consentStatus: linkStatusResult.consentStatus,
-        });
-        continue;
-      }
-
-      const paymentRequestResourceId =
-        linkStatusResult.data.paymentRequestResourceId;
-
-      if (!paymentRequestResourceId) {
-        console.warn(
-          '[HUBPISP][POLL_LINK] Link PROCESSED but missing paymentRequestResourceId',
-          {contextId},
-        );
-        continue;
-      }
-
-      console.log(
-        '[HUBPISP][POLL_LINK] Link PROCESSED, handing off to payment request poll',
-        {contextId, paymentRequestResourceId},
-      );
-
-      await updatePaymentContextData({
-        id: paymentContext.id,
-        version: paymentContext.version,
-        client,
-        context: {...paymentContext.data, paymentRequestResourceId},
-      });
-
-      pollPaymentRequestStatus({
-        paymentRequestResourceId,
-        contextId: paymentContext.id,
+  const timer = setTimeout(
+    () => {
+      scheduledExpiryChecks.delete(resourceId);
+      reconcilePaymentLinkStatus({
+        resourceId,
+        contextId,
         tenantId,
         localInstrument,
+      }).catch(err => {
+        console.error('[HUBPISP][EXPIRY_CHECK] Reconciliation failed', {
+          resourceId,
+          contextId,
+          error: (err as Error).message,
+        });
       });
+    },
+    delaySeconds * 1000 + EXPIRY_CHECK_BUFFER_MS,
+  );
 
-      return;
-    }
-
-    console.warn(
-      '[HUBPISP][POLL_LINK] Deadline reached without PROCESSED state, marking expired',
-      {contextId, resourceId},
-    );
-
-    const tenant = await manager.getTenant(tenantId);
-    if (!tenant) return;
-    const {client} = tenant;
-
-    const paymentContext = await findPaymentContext({
-      id: contextId,
-      client,
-      mode: PaymentOption.hubpisp,
-      ignoreExpiration: true,
-    });
-    if (paymentContext?.status === CONTEXT_STATUS.pending) {
-      await markPaymentAsExpired({
-        contextId: paymentContext.id,
-        version: paymentContext.version,
-        client,
-      });
-    }
-  } finally {
-    activePolls.delete(resourceId);
-  }
+  // Don't keep the process alive solely for this timer.
+  (timer as {unref?: () => void}).unref?.();
 }

--- a/lib/core/payment/hubpisp/process.ts
+++ b/lib/core/payment/hubpisp/process.ts
@@ -58,6 +58,7 @@ export async function applyTransactionStatus({
     case HUBPISP_TRANSACTION_STATUS.RJCT:
       console.warn(`'[HUBPISP][WEBHOOK]' Payment rejected`, {
         contextId: paymentContext.id,
+        transactionStatus,
         statusReasonInformation,
       });
       await markPaymentAsFailed({

--- a/lib/core/payment/hubpisp/startup.ts
+++ b/lib/core/payment/hubpisp/startup.ts
@@ -2,7 +2,7 @@
 import {HUBPISP_DEFAULT_EXPIRE_IN} from './constants';
 import {findAllPendingHubPispContexts} from './orm';
 import {pollPaymentRequestStatus} from './poll';
-import {pollPaymentLinkStatus} from './pollLink';
+import {reconcilePaymentLinkStatus, scheduleLinkExpiryCheck} from './pollLink';
 import {manager} from '@/tenant';
 
 function getRemainingExpireIn(createdOn: Date): number | null {
@@ -19,7 +19,9 @@ function getRemainingExpireIn(createdOn: Date): number | null {
  * 1. Contexts with a paymentRequestResourceId — the link was PROCESSED before the restart.
  *    Resume pollPaymentRequestStatus to detect the final bank transfer status.
  * 2. Contexts with no paymentRequestResourceId — the server stopped before the link became
- *    PROCESSED. Resume pollPaymentLinkStatus to detect when it does.
+ *    PROCESSED. Do ONE reconciliation (catch up any webhook missed during downtime) and
+ *    re-arm the single expiry backstop for the remaining validity window. The webhook
+ *    remains the live driver — we do not resume any polling loop.
  */
 export async function resumeHubPispPolling({
   tenantId,
@@ -64,25 +66,59 @@ export async function resumeHubPispPolling({
       });
     } else {
       const remainingExpireIn = getRemainingExpireIn(ctx.createdOn);
+
       if (!remainingExpireIn) {
+        // Validity window already elapsed during downtime: reconcile once to catch
+        // up any missed PROCESSED/EXPIRED. If BPCE still reports the link valid, we
+        // leave expiry to BPCE (it pushes EXPIRED via webhook).
         console.log(
-          '[HUBPISP][STARTUP] Payment link already expired, skipping',
+          '[HUBPISP][STARTUP] Validity window elapsed, reconciling once',
           {contextId: ctx.contextId, resourceId: ctx.resourceId},
         );
+        reconcilePaymentLinkStatus({
+          resourceId: ctx.resourceId,
+          contextId: ctx.contextId,
+          tenantId: ctx.tenantId,
+          localInstrument: ctx.localInstrument,
+        }).catch(err => {
+          console.error('[HUBPISP][STARTUP] Reconciliation failed', {
+            contextId: ctx.contextId,
+            error: (err as Error).message,
+          });
+        });
         continue;
       }
-      console.log('[HUBPISP][STARTUP] Resuming payment link poll', {
-        contextId: ctx.contextId,
-        resourceId: ctx.resourceId,
-        localInstrument: ctx.localInstrument,
-        remainingExpireIn,
-      });
-      pollPaymentLinkStatus({
+
+      console.log(
+        '[HUBPISP][STARTUP] Reconciling link and re-arming expiry check',
+        {
+          contextId: ctx.contextId,
+          resourceId: ctx.resourceId,
+          localInstrument: ctx.localInstrument,
+          remainingExpireIn,
+        },
+      );
+
+      // One-shot catch-up for any webhook missed while the server was down.
+      reconcilePaymentLinkStatus({
         resourceId: ctx.resourceId,
         contextId: ctx.contextId,
         tenantId: ctx.tenantId,
         localInstrument: ctx.localInstrument,
-        expireIn: remainingExpireIn,
+      }).catch(err => {
+        console.error('[HUBPISP][STARTUP] Reconciliation failed', {
+          contextId: ctx.contextId,
+          error: (err as Error).message,
+        });
+      });
+
+      // Re-arm the single expiry backstop for the remaining window.
+      scheduleLinkExpiryCheck({
+        resourceId: ctx.resourceId,
+        contextId: ctx.contextId,
+        tenantId: ctx.tenantId,
+        localInstrument: ctx.localInstrument,
+        delaySeconds: remainingExpireIn,
       });
     }
   }

--- a/lib/core/payment/hubpisp/types.ts
+++ b/lib/core/payment/hubpisp/types.ts
@@ -18,7 +18,6 @@ export type HubPispContextData = PaymentContextData & {
 
 export type PsuInfo = {
   name: string;
-  email?: string;
 };
 
 export type PageConsentInfo = {

--- a/lib/core/payment/hubpisp/utils.ts
+++ b/lib/core/payment/hubpisp/utils.ts
@@ -73,8 +73,12 @@ export function buildParisISOString(timestampMs: number): string {
   );
 }
 
+/**
+ * Date header value per HUB PISP v1.5 §5.3.1.1 (generic header):
+ * F=YYYY-MM-DDTHH:mm:ss.SSSZ — ISO 8601 in UTC (e.g. 2026-05-29T07:38:34.123Z).
+ */
 export function getDateHeader(): string {
-  return new Date().toUTCString();
+  return new Date().toISOString();
 }
 
 export function buildRequestTarget(


### PR DESCRIPTION
 https://redmine.axelor.com/issues/113397
 
  - Remove payment-link polling after link creation; rely on the webhook for link-state updates (with a single expiry-check as fallback).
  - Use the webhook request body for the link data, with a fallback to fetch it when the body is missing.
  - Update the implementation to match the latest HUB PISP v1.5 spec.
  - Harden the webhook flow, incl. fixing the optimistic-lock version mismatch on the PROCESSED path.