### PR TITLE
refactor(notifications): schedule background side effects with after() (#112763)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/events/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/actions/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import {z} from 'zod';
+import {after} from 'next/server';
 import {headers} from 'next/headers';
 
 // ---- CORE IMPORTS ----//
@@ -250,13 +251,15 @@ export async function register(
       paymentMode!,
     );
 
-    createInvoice({
-      workspace,
-      config,
-      registrationId: registration.id,
-      currencyCode: $event.currency?.code,
-      paymentModeId,
-    }).then(res => {
+    after(async () => {
+      const res = await createInvoice({
+        workspace,
+        config,
+        registrationId: registration.id,
+        currencyCode: $event.currency?.code,
+        paymentModeId,
+      });
+
       if (res.error) {
         console.error('Invoice creation failed:', res.message);
       }
@@ -279,27 +282,31 @@ export async function register(
       locale: contact.localization?.code || DEFAULT_LOCALE,
       tenant: tenantId,
     });
-    notifyUser({
-      userId: contact.id,
-      tenantId,
-      workspaceURL,
-      client,
-      payload: {
-        title: await tr('You have been registered for an event!'),
-        body: `${registration.event!.eventTitle}`,
-        url: `${workspaceURL}/${SUBAPP_CODES.events}/${registration.event!.slug}`,
-        tag: NotificationTag.event(registration.event!.id),
-      },
+    after(async () => {
+      await notifyUser({
+        userId: contact.id,
+        tenantId,
+        workspaceURL,
+        client,
+        payload: {
+          title: await tr('You have been registered for an event!'),
+          body: `${registration.event!.eventTitle}`,
+          url: `${workspaceURL}/${SUBAPP_CODES.events}/${registration.event!.slug}`,
+          tag: NotificationTag.event(registration.event!.id),
+        },
+      });
     });
   }
 
-  generateRegistrationMailAction({
-    eventId,
-    participants,
-    workspaceURL,
-    client,
-    config,
-  });
+  after(() =>
+    generateRegistrationMailAction({
+      eventId,
+      participants,
+      workspaceURL,
+      client,
+      config,
+    }),
+  );
 
   return {success: true, data: clone(registration)};
 }
@@ -487,27 +494,29 @@ export const createComment: CreateComment = async formData => {
         locale: parentComment.partner.localization?.code || DEFAULT_LOCALE,
         tenant: tenantId,
       });
-      notifyUser({
-        userId: parentComment.partner.id,
-        tenantId,
-        workspaceURL,
-        client,
-        payload: {
-          title: await tr(
-            '{0} replied to your comment on {1}',
-            userName,
-            event.eventTitle ?? '',
-          ),
-          body: comment.note ?? '',
-          url: `${eventUrl}#comment-${comment.id}`,
-          tag: NotificationTag.eventReply(parentComment.id),
-        },
-        getReplacementTitle: count =>
-          tr(
-            'You have {0} new replies to your comment on "{1}"',
-            String(count),
-            event.eventTitle ?? '',
-          ),
+      after(async () => {
+        await notifyUser({
+          userId: parentComment.partner!.id,
+          tenantId,
+          workspaceURL,
+          client,
+          payload: {
+            title: await tr(
+              '{0} replied to your comment on {1}',
+              userName,
+              event.eventTitle ?? '',
+            ),
+            body: comment.note ?? '',
+            url: `${eventUrl}#comment-${comment.id}`,
+            tag: NotificationTag.eventReply(parentComment.id),
+          },
+          getReplacementTitle: count =>
+            tr(
+              'You have {0} new replies to your comment on "{1}"',
+              String(count),
+              event.eventTitle ?? '',
+            ),
+        });
       });
     }
 

--- a/app/[tenant]/[workspace]/(subapps)/forum/common/action/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/forum/common/action/action.ts
@@ -6,6 +6,7 @@ import {headers} from 'next/headers';
 import path from 'path';
 import {pipeline} from 'stream';
 import {promisify} from 'util';
+import {after} from 'next/server';
 import {revalidatePath} from 'next/cache';
 
 // ---- CORE IMPORTS ---- //
@@ -627,45 +628,50 @@ export async function addPost({
       const postLink = `${workspaceURL}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${group.id}?searchid=${post.id}#post-${post.id}`;
 
       for (const reciever of subscribers) {
+        const member = reciever.member;
         if (
-          reciever.member?.id &&
-          reciever.member.id !== user.id // exclude the post author
+          member?.id &&
+          member.id !== user.id // exclude the post author
         ) {
           const tr = getTranslation.bind(null, {
-            locale: reciever.member.localization?.code || DEFAULT_LOCALE,
+            locale: member.localization?.code || DEFAULT_LOCALE,
             tenant: tenantId,
           });
-          notifyUser({
-            userId: reciever.member.id,
-            tenantId,
-            workspaceURL,
-            client,
-            payload: {
-              title: await tr(
-                '{0} created a new post',
-                user.simpleFullName || user.name || '',
-              ),
-              body: post?.title ?? '',
-              url: postLink,
-              tag: NotificationTag.forumNewPost(post.id),
-            },
+          after(async () => {
+            await notifyUser({
+              userId: member.id,
+              tenantId,
+              workspaceURL,
+              client,
+              payload: {
+                title: await tr(
+                  '{0} created a new post',
+                  user.simpleFullName || user.name || '',
+                ),
+                body: post?.title ?? '',
+                url: postLink,
+                tag: NotificationTag.forumNewPost(post.id),
+              },
+            });
           });
         }
       }
 
       if (post?.author && post?.forumGroup) {
-        sendEmailNotifications({
-          type: ContentType.POST,
-          title: post?.title ?? '',
-          content: post?.content ?? '',
-          author: {
-            id: post.author.id,
-            simpleFullName: post.author.simpleFullName ?? '',
-          },
-          group: {name: post.forumGroup.name ?? ''},
-          subscribers,
-          link: postLink,
-        });
+        after(() =>
+          sendEmailNotifications({
+            type: ContentType.POST,
+            title: post?.title ?? '',
+            content: post?.content ?? '',
+            author: {
+              id: post.author!.id,
+              simpleFullName: post.author!.simpleFullName ?? '',
+            },
+            group: {name: post.forumGroup!.name ?? ''},
+            subscribers,
+            link: postLink,
+          }),
+        );
       }
     }
     revalidatePath(`${workspaceURI}/${SUBAPP_CODES.forum}`);
@@ -1032,24 +1038,29 @@ export const createComment: CreateComment = async formData => {
                   parentComment.partner.localization?.code || DEFAULT_LOCALE,
                 tenant: tenantId,
               });
-              notifyUser({
-                userId: parentComment.partner.id,
-                tenantId,
-                workspaceURL,
-                client,
-                payload: {
-                  title: await tr(
-                    '{0} replied to your comment',
-                    user.simpleFullName || user.name || '',
-                  ),
-                  body: comment.note ?? '',
-                  url: withBasePath(
-                    `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
-                  ),
-                  tag: NotificationTag.forumReply(parentComment.id),
-                },
-                getReplacementTitle: count =>
-                  tr('You have {0} new replies to your comment', String(count)),
+              after(async () => {
+                await notifyUser({
+                  userId: parentComment.partner!.id,
+                  tenantId,
+                  workspaceURL,
+                  client,
+                  payload: {
+                    title: await tr(
+                      '{0} replied to your comment',
+                      user.simpleFullName || user.name || '',
+                    ),
+                    body: comment.note ?? '',
+                    url: withBasePath(
+                      `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
+                    ),
+                    tag: NotificationTag.forumReply(parentComment.id),
+                  },
+                  getReplacementTitle: count =>
+                    tr(
+                      'You have {0} new replies to your comment',
+                      String(count),
+                    ),
+                });
               });
 
               const replySubscriber = notificationRecievers.find(
@@ -1057,22 +1068,24 @@ export const createComment: CreateComment = async formData => {
               );
 
               if (replySubscriber) {
-                sendEmailNotifications({
-                  type: ContentType.COMMENT,
-                  title: post.title ?? '',
-                  content: comment.note ?? '',
-                  author: {
-                    id: comment?.partner?.id ?? '',
-                    simpleFullName:
-                      comment?.partner?.simpleFullName ?? 'Unknown User',
-                  },
-                  postAuthor: {
-                    id: post?.author?.id ?? '',
-                  },
-                  group: post.forumGroup,
-                  subscribers: [replySubscriber],
-                  link: postLink,
-                });
+                after(() =>
+                  sendEmailNotifications({
+                    type: ContentType.COMMENT,
+                    title: post.title ?? '',
+                    content: comment.note ?? '',
+                    author: {
+                      id: comment?.partner?.id ?? '',
+                      simpleFullName:
+                        comment?.partner?.simpleFullName ?? 'Unknown User',
+                    },
+                    postAuthor: {
+                      id: post?.author?.id ?? '',
+                    },
+                    group: post.forumGroup,
+                    subscribers: [replySubscriber],
+                    link: postLink,
+                  }),
+                );
               }
             }
           } else {
@@ -1082,48 +1095,52 @@ export const createComment: CreateComment = async formData => {
                   locale: reciever.member.localization?.code || DEFAULT_LOCALE,
                   tenant: tenantId,
                 });
-                notifyUser({
-                  userId: reciever.member.id,
-                  tenantId,
-                  workspaceURL,
-                  client,
-                  payload: {
-                    title: await tr(
-                      '{0} added a comment',
-                      user.simpleFullName || user.name || '',
-                    ),
-                    body: comment.note ?? '',
-                    url: withBasePath(
-                      `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
-                    ),
-                    tag: NotificationTag.forumPostComment(post.id),
-                  },
-                  getReplacementTitle: count =>
-                    tr(
-                      'You have {0} new comments on "{1}"',
-                      String(count),
-                      post.title ?? '',
-                    ),
+                after(async () => {
+                  await notifyUser({
+                    userId: reciever.member!.id,
+                    tenantId,
+                    workspaceURL,
+                    client,
+                    payload: {
+                      title: await tr(
+                        '{0} added a comment',
+                        user.simpleFullName || user.name || '',
+                      ),
+                      body: comment.note ?? '',
+                      url: withBasePath(
+                        `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
+                      ),
+                      tag: NotificationTag.forumPostComment(post.id),
+                    },
+                    getReplacementTitle: count =>
+                      tr(
+                        'You have {0} new comments on "{1}"',
+                        String(count),
+                        post.title ?? '',
+                      ),
+                  });
                 });
               }
             }
 
-            sendEmailNotifications({
-              type: ContentType.COMMENT,
-              title: post.title ?? '',
-              content: comment.note ?? '',
-              author: {
-                id: comment?.partner?.id ?? '',
-                simpleFullName:
-                  comment?.partner?.simpleFullName ?? 'Unknown User',
-              },
-              postAuthor: {
-                id: post?.author?.id ?? '',
-              },
-              group: post.forumGroup,
-              subscribers: notificationRecievers,
-              link: postLink,
-            });
+            after(() =>
+              sendEmailNotifications({
+                type: ContentType.COMMENT,
+                title: post.title ?? '',
+                content: comment.note ?? '',
+                author: {
+                  id: comment?.partner?.id ?? '',
+                  simpleFullName:
+                    comment?.partner?.simpleFullName ?? 'Unknown User',
+                },
+                postAuthor: {
+                  id: post?.author?.id ?? '',
+                },
+                group: post.forumGroup,
+                subscribers: notificationRecievers,
+                link: postLink,
+              }),
+            );
           }
         }
       }

--- a/app/[tenant]/[workspace]/(subapps)/forum/common/utils/mail.ts
+++ b/app/[tenant]/[workspace]/(subapps)/forum/common/utils/mail.ts
@@ -75,7 +75,7 @@ export const sendEmailNotifications = async ({
           user: subscriber.member?.simpleFullName || '',
         });
 
-        mailService.notify({
+        await mailService.notify({
           to: subscriber.member.emailAddress.address,
           subject: `New ${type}: ${title}`,
           html: emailContent,

--- a/app/[tenant]/[workspace]/(subapps)/invoices/common/utils/notify.ts
+++ b/app/[tenant]/[workspace]/(subapps)/invoices/common/utils/notify.ts
@@ -42,7 +42,7 @@ export async function notifyInvoicePaymentSuccess({
       locale: user.localization?.code || DEFAULT_LOCALE,
       tenant: tenantId,
     });
-    notifyUser({
+    await notifyUser({
       userId: user.id,
       tenantId,
       client,

--- a/app/[tenant]/[workspace]/(subapps)/news/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/news/common/actions/action.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import {z} from 'zod';
+import {after} from 'next/server';
 import {headers} from 'next/headers';
 
 // ---- CORE IMPORTS ---- //
@@ -233,27 +234,29 @@ export const createComment: CreateComment = async formData => {
         locale: parentComment.partner.localization?.code || DEFAULT_LOCALE,
         tenant: tenantId,
       });
-      notifyUser({
-        userId: parentComment.partner.id,
-        tenantId,
-        workspaceURL,
-        client,
-        payload: {
-          title: await tr(
-            '{0} replied to your comment on {1}',
-            userName ?? '',
-            newsItem.title ?? '',
-          ),
-          body: comment.note ?? '',
-          url: newsUrl,
-          tag: NotificationTag.newsReply(parentComment.id),
-        },
-        getReplacementTitle: count =>
-          tr(
-            'You have {0} new replies to your comment on "{1}"',
-            String(count),
-            newsItem.title ?? '',
-          ),
+      after(async () => {
+        await notifyUser({
+          userId: parentComment.partner!.id,
+          tenantId,
+          workspaceURL,
+          client,
+          payload: {
+            title: await tr(
+              '{0} replied to your comment on {1}',
+              userName ?? '',
+              newsItem.title ?? '',
+            ),
+            body: comment.note ?? '',
+            url: newsUrl,
+            tag: NotificationTag.newsReply(parentComment.id),
+          },
+          getReplacementTitle: count =>
+            tr(
+              'You have {0} new replies to your comment on "{1}"',
+              String(count),
+              newsItem.title ?? '',
+            ),
+        });
       });
     }
 

--- a/app/[tenant]/[workspace]/(subapps)/quotations/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/quotations/common/actions/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import {after} from 'next/server';
 import {headers} from 'next/headers';
 
 // ---- CORE IMPORTS ---- //
@@ -115,27 +116,29 @@ export const createComment: CreateComment = async formData => {
         locale: parentComment.partner.localization?.code || DEFAULT_LOCALE,
         tenant: tenantId,
       });
-      notifyUser({
-        userId: parentComment.partner.id,
-        tenantId,
-        client,
-        workspaceURL,
-        payload: {
-          title: await tr(
-            '{0} replied to your comment on {1}',
-            userName ?? '',
-            quotation.saleOrderSeq ?? '',
-          ),
-          body: comment.body ?? '',
-          url: `${quotationUrl}#comment-${comment.id}`,
-          tag: NotificationTag.quotationReply(parentComment.id),
-        },
-        getReplacementTitle: count =>
-          tr(
-            'You have {0} new replies to your comment on "{1}"',
-            String(count),
-            quotation.saleOrderSeq ?? '',
-          ),
+      after(async () => {
+        await notifyUser({
+          userId: parentComment.partner!.id,
+          tenantId,
+          client,
+          workspaceURL,
+          payload: {
+            title: await tr(
+              '{0} replied to your comment on {1}',
+              userName ?? '',
+              quotation.saleOrderSeq ?? '',
+            ),
+            body: comment.body ?? '',
+            url: `${quotationUrl}#comment-${comment.id}`,
+            tag: NotificationTag.quotationReply(parentComment.id),
+          },
+          getReplacementTitle: count =>
+            tr(
+              'You have {0} new replies to your comment on "{1}"',
+              String(count),
+              quotation.saleOrderSeq ?? '',
+            ),
+        });
       });
     }
 

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
@@ -48,6 +48,7 @@ import {
   updateTicket,
 } from '../orm/tickets';
 import {ensureAuth} from '../utils/auth-helper';
+import {notifyTicketChange} from '../utils/notify';
 import {CreateTicketSchema, UpdateTicketSchema} from '../utils/validators';
 import {handleError} from './helpers';
 import type {ActionConfig, MutateProps} from './types';
@@ -160,19 +161,33 @@ export async function mutate(
          so we wrap in a transaction to keep them atomic. */
       const {user, subapp} = auth;
       const {client} = auth.tenant;
-      ticket = await client.$transaction(txClient =>
+      const {
+        ticket: created,
+        tracks,
+        contacts,
+      } = await client.$transaction(txClient =>
         createTicket({
           data: createData,
-          workspaceUserId: workspace.workspaceUser?.id,
           client: txClient,
-          backgroundClient: client,
           user,
           subapp,
           workspace,
-          tenantId,
-          workspaceURL,
         }),
       );
+      after(() =>
+        notifyTicketChange({
+          type: 'create',
+          ticket: created,
+          tracks,
+          contacts,
+          user,
+          workspaceUserId: workspace.workspaceUser?.id,
+          workspaceURL,
+          tenantId,
+          client,
+        }),
+      );
+      ticket = created;
     } else {
       const refinedSchema = UpdateTicketSchema.superRefine(
         async (data, ctx) => {
@@ -208,17 +223,32 @@ export async function mutate(
         const version = await findTicketVersion(updateData.id, client);
         updateData.version = version;
       }
-      ticket = await updateTicket({
+      const {
+        ticket: updated,
+        tracks,
+        contacts,
+      } = await updateTicket({
         data: updateData,
-        workspaceUserId: workspace.workspaceUser?.id,
         client: auth.tenant.client,
-        backgroundClient: auth.tenant.client,
         user: auth.user,
         subapp: auth.subapp,
         workspace,
         tenant: auth.tenant,
-        workspaceURL,
       });
+      after(() =>
+        notifyTicketChange({
+          type: 'update',
+          ticket: updated,
+          tracks,
+          contacts,
+          user: auth.user,
+          workspaceUserId: workspace.workspaceUser?.id,
+          workspaceURL,
+          tenantId,
+          client: auth.tenant.client,
+        }),
+      );
+      ticket = updated;
     }
 
     if (ticket.project?.id) {
@@ -287,18 +317,28 @@ export async function updateAssignment(
     const fromWS =
       workspace.config.ticketStatusChangeMethod === STATUS_CHANGE_METHOD.WS;
 
-    await updateTicket({
+    const {ticket, tracks, contacts} = await updateTicket({
       data: updateData,
-      workspaceUserId: workspaceUser?.id,
       client: auth.tenant.client,
-      backgroundClient: auth.tenant.client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
       tenant: auth.tenant,
-      workspaceURL,
       fromWS,
     });
+    after(() =>
+      notifyTicketChange({
+        type: 'update',
+        ticket,
+        tracks,
+        contacts,
+        user: auth.user,
+        workspaceUserId: fromWS ? undefined : workspaceUser?.id,
+        workspaceURL,
+        tenantId,
+        client: auth.tenant.client,
+      }),
+    );
     return {success: true, data: true};
   } catch (e) {
     return handleError(e);
@@ -366,18 +406,28 @@ export async function closeTicket(
     const fromWS =
       workspace.config.ticketStatusChangeMethod === STATUS_CHANGE_METHOD.WS;
 
-    await updateTicket({
+    const {ticket, tracks, contacts} = await updateTicket({
       data: updateData,
-      workspaceUserId: workspaceUser?.id,
       client,
-      backgroundClient: client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
       tenant: auth.tenant,
-      workspaceURL,
       fromWS,
     });
+    after(() =>
+      notifyTicketChange({
+        type: 'update',
+        ticket,
+        tracks,
+        contacts,
+        user: auth.user,
+        workspaceUserId: fromWS ? undefined : workspaceUser?.id,
+        workspaceURL,
+        tenantId,
+        client,
+      }),
+    );
 
     return {success: true, data: true};
   } catch (e) {
@@ -440,18 +490,28 @@ export async function cancelTicket(
     const fromWS =
       workspace.config.ticketStatusChangeMethod === STATUS_CHANGE_METHOD.WS;
 
-    await updateTicket({
+    const {ticket, tracks, contacts} = await updateTicket({
       data: updateData,
-      workspaceUserId: workspaceUser?.id,
       client,
-      backgroundClient: client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
       tenant: auth.tenant,
-      workspaceURL,
       fromWS,
     });
+    after(() =>
+      notifyTicketChange({
+        type: 'update',
+        ticket,
+        tracks,
+        contacts,
+        user: auth.user,
+        workspaceUserId: fromWS ? undefined : workspaceUser?.id,
+        workspaceURL,
+        tenantId,
+        client,
+      }),
+    );
 
     return {success: true, data: true};
   } catch (e) {

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import {after} from 'next/server';
 import {revalidatePath} from 'next/cache';
 import {headers} from 'next/headers';
 import {ZodIssueCode} from 'zod';
@@ -164,6 +165,7 @@ export async function mutate(
           data: createData,
           workspaceUserId: workspace.workspaceUser?.id,
           client: txClient,
+          backgroundClient: client,
           user,
           subapp,
           workspace,
@@ -210,6 +212,7 @@ export async function mutate(
         data: updateData,
         workspaceUserId: workspace.workspaceUser?.id,
         client: auth.tenant.client,
+        backgroundClient: auth.tenant.client,
         user: auth.user,
         subapp: auth.subapp,
         workspace,
@@ -288,6 +291,7 @@ export async function updateAssignment(
       data: updateData,
       workspaceUserId: workspaceUser?.id,
       client: auth.tenant.client,
+      backgroundClient: auth.tenant.client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
@@ -366,6 +370,7 @@ export async function closeTicket(
       data: updateData,
       workspaceUserId: workspaceUser?.id,
       client,
+      backgroundClient: client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
@@ -439,6 +444,7 @@ export async function cancelTicket(
       data: updateData,
       workspaceUserId: workspaceUser?.id,
       client,
+      backgroundClient: client,
       user: auth.user,
       subapp: auth.subapp,
       workspace,
@@ -848,27 +854,29 @@ export const createComment: CreateComment = async formData => {
           locale: partner.localization?.code || DEFAULT_LOCALE,
           tenant: tenantId,
         });
-        notifyUser({
-          userId: partner.id,
-          tenantId,
-          workspaceURL,
-          client,
-          payload: {
-            title: await tr(
-              '{0} replied to your comment on {1}',
-              userName,
-              ticket.name,
-            ),
-            body: commentBody,
-            url: `${ticketUrl}#comment-${comment.id}`,
-            tag: NotificationTag.ticketReply(parentComment.id),
-          },
-          getReplacementTitle: count =>
-            tr(
-              'You have {0} new replies to your comment on "{1}"',
-              String(count),
-              ticket.name,
-            ),
+        after(async () => {
+          await notifyUser({
+            userId: partner.id,
+            tenantId,
+            workspaceURL,
+            client,
+            payload: {
+              title: await tr(
+                '{0} replied to your comment on {1}',
+                userName,
+                ticket.name,
+              ),
+              body: commentBody,
+              url: `${ticketUrl}#comment-${comment.id}`,
+              tag: NotificationTag.ticketReply(parentComment.id),
+            },
+            getReplacementTitle: count =>
+              tr(
+                'You have {0} new replies to your comment on "{1}"',
+                String(count),
+                ticket.name,
+              ),
+          });
         });
       }
     } else {
@@ -877,39 +885,42 @@ export const createComment: CreateComment = async formData => {
           locale: contact.localization?.code || DEFAULT_LOCALE,
           tenant: tenantId,
         });
-        notifyUser({
-          userId: contact.id,
-          tenantId,
-          workspaceURL,
-          client,
-          payload: {
-            title: await tr(
-              '{0} added a comment on {1}',
-              userName,
-              String(ticket.name),
-            ),
-            body: commentBody,
-            url: `${ticketUrl}#comment-${comment.id}`,
-            tag: NotificationTag.ticketComment(ticket.id),
-          },
-          getReplacementTitle: count =>
-            tr(
-              'You have {0} new comments on "{1}"',
-              String(count),
-              String(ticket.name),
-            ),
+        after(async () => {
+          await notifyUser({
+            userId: contact.id,
+            tenantId,
+            workspaceURL,
+            client,
+            payload: {
+              title: await tr(
+                '{0} added a comment on {1}',
+                userName,
+                String(ticket.name),
+              ),
+              body: commentBody,
+              url: `${ticketUrl}#comment-${comment.id}`,
+              tag: NotificationTag.ticketComment(ticket.id),
+            },
+            getReplacementTitle: count =>
+              tr(
+                'You have {0} new comments on "{1}"',
+                String(count),
+                String(ticket.name),
+              ),
+          });
         });
       }
     }
 
-    getMailRecipients({
-      contacts,
-      client,
-      workspaceURL,
-    })
-      .then(reciepients => {
+    after(async () => {
+      try {
+        const reciepients = await getMailRecipients({
+          contacts,
+          client,
+          workspaceURL,
+        });
         if (reciepients.length) {
-          return sendCommentMail({
+          await sendCommentMail({
             comment,
             parentComment,
             ticketLink: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${ticket.project?.id}/tickets/${ticket.id}`,
@@ -919,11 +930,11 @@ export const createComment: CreateComment = async formData => {
             tenant: tenantId,
           });
         }
-      })
-      .catch(e => {
+      } catch (e) {
         console.error('Error sending comment email: ');
         console.error(e);
-      });
+      }
+    });
 
     return {success: true, data: clone(res)};
   } catch (e) {

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/orm/tickets.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/orm/tickets.ts
@@ -1,6 +1,7 @@
 import type {Entity, Payload, SelectOptions, UpdateArgs} from '@goovee/orm';
 import type {ID} from '@/types';
 import axios from 'axios';
+import {after} from 'next/server';
 
 // ---- CORE IMPORTS ---- //
 import {getAOSAuthHeaders} from '@/tenant/auth';
@@ -82,6 +83,7 @@ export async function createTicket({
   data,
   workspaceUserId,
   client,
+  backgroundClient,
   user,
   subapp,
   workspace,
@@ -91,6 +93,7 @@ export async function createTicket({
   data: CreateTicketInfo;
   workspaceUserId?: ID;
   client: Client;
+  backgroundClient?: Client;
   user: UserCtx;
   subapp: SubappCtx;
   workspace: WorkspaceCtx;
@@ -190,7 +193,7 @@ export async function createTicket({
       isInternal: true,
       progress: true,
       createdByContact: {id: true, name: true, localization: {code: true}},
-      project: {name: true},
+      project: {id: true, name: true},
       ...(managedBy && {
         managedByContact: {id: true, name: true, localization: {code: true}},
       }),
@@ -269,62 +272,71 @@ export async function createTicket({
       value: newTicket.managedByContact?.name ?? '',
     });
   }
-  try {
-    if (workspaceUserId) {
-      addComment({
-        modelName: ModelMap[SUBAPP_CODES.ticketing]!,
-        userId: user.id,
-        workspaceUserId: workspaceUserId,
-        recordId: newTicket.id,
-        subject: `Record Created by ${user.simpleFullName}`,
-        messageBody: {title: 'Record created', tracks: tracks, tags: []},
-        messageType: MAIL_MESSAGE_TYPE.notification,
-        client,
-        trackingField: 'publicBody',
-        commentField: 'note',
-      });
-    }
-  } catch (e) {
-    console.error('Error adding comment');
-    console.error(e);
-  }
-
   const contacts = uniqueById([
     newTicket.createdByContact,
     newTicket.managedByContact,
   ]).filter(c => String(c.id) !== String(user.id)); // exclude the ticket creator — they performed the action
 
-  for (const contact of contacts) {
-    const tr = getTranslation.bind(null, {
-      locale: contact.localization?.code || DEFAULT_LOCALE,
-      tenant: tenantId,
-    });
-    notifyUser({
-      userId: contact.id,
-      tenantId,
-      client,
-      workspaceURL,
-      payload: {
-        title: await tr('{0} created a new ticket', user.simpleFullName ?? ''),
-        body: await tr(
-          '{0} created a new ticket: {1}',
-          user.simpleFullName ?? '',
-          String(newTicket.name),
-        ),
-        url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-        tag: NotificationTag.ticketUpdate(newTicket.id),
-      },
-    });
-  }
+  after(async () => {
+    // Use backgroundClient when called inside a transaction — txClient is dead by the time after() fires.
+    const sideEffectClient = backgroundClient ?? client;
 
-  getMailRecipients({
-    contacts,
-    client,
-    workspaceURL,
-  })
-    .then(reciepients => {
+    try {
+      if (workspaceUserId) {
+        await addComment({
+          modelName: ModelMap[SUBAPP_CODES.ticketing]!,
+          userId: user.id,
+          workspaceUserId: workspaceUserId,
+          recordId: newTicket.id,
+          subject: `Record Created by ${user.simpleFullName}`,
+          messageBody: {title: 'Record created', tracks: tracks, tags: []},
+          messageType: MAIL_MESSAGE_TYPE.notification,
+          client: sideEffectClient,
+          trackingField: 'publicBody',
+          commentField: 'note',
+        });
+      }
+    } catch (e) {
+      console.error('Error adding comment');
+      console.error(e);
+    }
+
+    await Promise.all(
+      contacts.map(async contact => {
+        const tr = getTranslation.bind(null, {
+          locale: contact.localization?.code || DEFAULT_LOCALE,
+          tenant: tenantId,
+        });
+        await notifyUser({
+          userId: contact.id,
+          tenantId,
+          client: sideEffectClient,
+          workspaceURL,
+          payload: {
+            title: await tr(
+              '{0} created a new ticket',
+              user.simpleFullName ?? '',
+            ),
+            body: await tr(
+              '{0} created a new ticket: {1}',
+              user.simpleFullName ?? '',
+              String(newTicket.name),
+            ),
+            url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
+            tag: NotificationTag.ticketUpdate(newTicket.id),
+          },
+        });
+      }),
+    );
+
+    try {
+      const reciepients = await getMailRecipients({
+        contacts,
+        client: sideEffectClient,
+        workspaceURL,
+      });
       if (reciepients.length) {
-        return sendTrackMail({
+        await sendTrackMail({
           author: user.simpleFullName || '',
           type: 'create',
           tracks,
@@ -335,11 +347,11 @@ export async function createTicket({
           tenant: tenantId,
         });
       }
-    })
-    .catch(e => {
+    } catch (e) {
       console.error('Error sending tracking email: ');
       console.error(e);
-    });
+    }
+  });
 
   return newTicket;
 }
@@ -361,6 +373,7 @@ export type UTicket = Payload<AOSProjectTask, {select: typeof updateSelect}>;
 export async function updateTicket({
   data,
   client,
+  backgroundClient,
   user,
   subapp,
   workspace,
@@ -371,6 +384,7 @@ export async function updateTicket({
 }: {
   data: UpdateTicketInfo;
   client: Client;
+  backgroundClient?: Client;
   user: UserCtx;
   subapp: SubappCtx;
   workspace: WorkspaceCtx;
@@ -541,63 +555,69 @@ export async function updateTicket({
     });
   }
 
-  try {
-    if (workspaceUserId && !fromWS) {
-      addComment({
-        modelName: ModelMap[SUBAPP_CODES.ticketing]!,
-        userId: user.id,
-        workspaceUserId: workspaceUserId,
-        recordId: newTicket.id,
-        subject: `Record Updated by ${user.simpleFullName}`,
-        messageBody: {title: 'Record updated', tracks: tracks, tags: []},
-        messageType: MAIL_MESSAGE_TYPE.notification,
-        client,
-        trackingField: 'publicBody',
-        commentField: 'note',
-      });
-    }
-  } catch (e) {
-    console.log('Error adding comment');
-    console.error(e);
-  }
-
   const contacts = uniqueById([
     newTicket.createdByContact,
     newTicket.managedByContact,
     oldTicket?.managedByContact,
   ]).filter(c => String(c.id) !== String(user.id)); // exclude the user who performed the update
 
-  for (const contact of contacts) {
-    const tr = getTranslation.bind(null, {
-      locale: contact.localization?.code || DEFAULT_LOCALE,
-      tenant: tenant.id,
-    });
-    notifyUser({
-      userId: contact.id,
-      tenantId: tenant.id,
-      client,
-      workspaceURL,
-      payload: {
-        title: await tr('{0} updated a ticket', user.simpleFullName ?? ''),
-        body: await tr(
-          '{0} updated a ticket: {1}',
-          user.simpleFullName ?? '',
-          String(newTicket.name),
-        ),
-        url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-        tag: NotificationTag.ticketUpdate(newTicket.id),
-      },
-    });
-  }
+  after(async () => {
+    // Use backgroundClient when called inside a transaction — txClient is dead by the time after() fires.
+    const sideEffectClient = backgroundClient ?? client;
 
-  getMailRecipients({
-    contacts,
-    client,
-    workspaceURL,
-  })
-    .then(reciepients => {
+    try {
+      if (workspaceUserId && !fromWS) {
+        await addComment({
+          modelName: ModelMap[SUBAPP_CODES.ticketing]!,
+          userId: user.id,
+          workspaceUserId: workspaceUserId,
+          recordId: newTicket.id,
+          subject: `Record Updated by ${user.simpleFullName}`,
+          messageBody: {title: 'Record updated', tracks: tracks, tags: []},
+          messageType: MAIL_MESSAGE_TYPE.notification,
+          client: sideEffectClient,
+          trackingField: 'publicBody',
+          commentField: 'note',
+        });
+      }
+    } catch (e) {
+      console.log('Error adding comment');
+      console.error(e);
+    }
+
+    await Promise.all(
+      contacts.map(async contact => {
+        const tr = getTranslation.bind(null, {
+          locale: contact.localization?.code || DEFAULT_LOCALE,
+          tenant: tenant.id,
+        });
+        await notifyUser({
+          userId: contact.id,
+          tenantId: tenant.id,
+          client: sideEffectClient,
+          workspaceURL,
+          payload: {
+            title: await tr('{0} updated a ticket', user.simpleFullName ?? ''),
+            body: await tr(
+              '{0} updated a ticket: {1}',
+              user.simpleFullName ?? '',
+              String(newTicket.name),
+            ),
+            url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
+            tag: NotificationTag.ticketUpdate(newTicket.id),
+          },
+        });
+      }),
+    );
+
+    try {
+      const reciepients = await getMailRecipients({
+        contacts,
+        client: sideEffectClient,
+        workspaceURL,
+      });
       if (reciepients.length) {
-        return sendTrackMail({
+        await sendTrackMail({
           author: user.simpleFullName || '',
           type: 'update',
           tracks,
@@ -608,11 +628,11 @@ export async function updateTicket({
           tenant: tenant.id,
         });
       }
-    })
-    .catch(e => {
+    } catch (e) {
       console.error('Error sending tracking email: ');
       console.error(e);
-    });
+    }
+  });
   return newTicket;
 }
 

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/orm/tickets.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/orm/tickets.ts
@@ -1,16 +1,13 @@
 import type {Entity, Payload, SelectOptions, UpdateArgs} from '@goovee/orm';
 import type {ID} from '@/types';
 import axios from 'axios';
-import {after} from 'next/server';
 
 // ---- CORE IMPORTS ---- //
 import {getAOSAuthHeaders} from '@/tenant/auth';
-import {MAIL_MESSAGE_TYPE, type Track} from '@/comments';
-import {addComment} from '@/comments/orm';
-import {ModelMap, ORDER_BY, SUBAPP_CODES} from '@/constants';
+import {type Track} from '@/comments';
+import {ORDER_BY} from '@/constants';
 import type {AOSProjectTask} from '@/goovee/.generated/models';
-import {t, getTranslation} from '@/locale/server';
-import {DEFAULT_LOCALE} from '@/locale/contants';
+import {t} from '@/locale/server';
 import type {Client} from '@/goovee/.generated/client';
 import {uniqueById} from '@/utils';
 import {sql} from '@/utils/template-string';
@@ -32,15 +29,11 @@ import type {
   TicketListTicket,
   TicketSearch,
 } from '../types';
-import {sendTrackMail} from '../utils/mail';
 import {findTicketStatuses} from './projects';
 import type {CreateTicketInfo, UpdateTicketInfo} from '../utils/validators';
 import type {QueryProps, UserCtx, SubappCtx, WorkspaceCtx} from './helpers';
 import {getProjectAccessFilter, withTicketAccessFilter} from './helpers';
 import type {Tenant} from '@/tenant';
-import {getMailRecipients} from './mail';
-import {notifyUser} from '@/pwa/utils';
-import {NotificationTag} from '@/pwa/tags';
 
 export type TicketProps<T extends Entity> = QueryProps<T> & {
   projectId: ID;
@@ -81,24 +74,16 @@ export async function findTicketAccess<
 
 export async function createTicket({
   data,
-  workspaceUserId,
   client,
-  backgroundClient,
   user,
   subapp,
   workspace,
-  tenantId,
-  workspaceURL,
 }: {
   data: CreateTicketInfo;
-  workspaceUserId?: ID;
   client: Client;
-  backgroundClient?: Client;
   user: UserCtx;
   subapp: SubappCtx;
   workspace: WorkspaceCtx;
-  tenantId: string;
-  workspaceURL: string;
 }) {
   const {
     priority,
@@ -277,83 +262,7 @@ export async function createTicket({
     newTicket.managedByContact,
   ]).filter(c => String(c.id) !== String(user.id)); // exclude the ticket creator — they performed the action
 
-  after(async () => {
-    // Use backgroundClient when called inside a transaction — txClient is dead by the time after() fires.
-    const sideEffectClient = backgroundClient ?? client;
-
-    try {
-      if (workspaceUserId) {
-        await addComment({
-          modelName: ModelMap[SUBAPP_CODES.ticketing]!,
-          userId: user.id,
-          workspaceUserId: workspaceUserId,
-          recordId: newTicket.id,
-          subject: `Record Created by ${user.simpleFullName}`,
-          messageBody: {title: 'Record created', tracks: tracks, tags: []},
-          messageType: MAIL_MESSAGE_TYPE.notification,
-          client: sideEffectClient,
-          trackingField: 'publicBody',
-          commentField: 'note',
-        });
-      }
-    } catch (e) {
-      console.error('Error adding comment');
-      console.error(e);
-    }
-
-    await Promise.all(
-      contacts.map(async contact => {
-        const tr = getTranslation.bind(null, {
-          locale: contact.localization?.code || DEFAULT_LOCALE,
-          tenant: tenantId,
-        });
-        await notifyUser({
-          userId: contact.id,
-          tenantId,
-          client: sideEffectClient,
-          workspaceURL,
-          payload: {
-            title: await tr(
-              '{0} created a new ticket',
-              user.simpleFullName ?? '',
-            ),
-            body: await tr(
-              '{0} created a new ticket: {1}',
-              user.simpleFullName ?? '',
-              String(newTicket.name),
-            ),
-            url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-            tag: NotificationTag.ticketUpdate(newTicket.id),
-          },
-        });
-      }),
-    );
-
-    try {
-      const reciepients = await getMailRecipients({
-        contacts,
-        client: sideEffectClient,
-        workspaceURL,
-      });
-      if (reciepients.length) {
-        await sendTrackMail({
-          author: user.simpleFullName || '',
-          type: 'create',
-          tracks,
-          projectName: newTicket.project?.name || '',
-          ticketName: newTicket.name,
-          ticketLink: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-          reciepients,
-          tenant: tenantId,
-        });
-      }
-    } catch (e) {
-      console.error('Error sending tracking email: ');
-      console.error(e);
-    }
-  });
-
-  return newTicket;
+  return {ticket: newTicket, tracks, contacts};
 }
 
 const updateSelect = {
@@ -373,26 +282,20 @@ export type UTicket = Payload<AOSProjectTask, {select: typeof updateSelect}>;
 export async function updateTicket({
   data,
   client,
-  backgroundClient,
   user,
   subapp,
   workspace,
   tenant,
-  workspaceURL,
   fromWS,
-  workspaceUserId,
 }: {
   data: UpdateTicketInfo;
   client: Client;
-  backgroundClient?: Client;
   user: UserCtx;
   subapp: SubappCtx;
   workspace: WorkspaceCtx;
   tenant: Tenant;
-  workspaceURL: string;
-  workspaceUserId?: ID;
   fromWS?: boolean;
-}): Promise<UTicket> {
+}) {
   const {priority, category, status, assignment, managedBy, id, version} = data;
 
   const oldTicket = await findTicketAccess({
@@ -561,79 +464,7 @@ export async function updateTicket({
     oldTicket?.managedByContact,
   ]).filter(c => String(c.id) !== String(user.id)); // exclude the user who performed the update
 
-  after(async () => {
-    // Use backgroundClient when called inside a transaction — txClient is dead by the time after() fires.
-    const sideEffectClient = backgroundClient ?? client;
-
-    try {
-      if (workspaceUserId && !fromWS) {
-        await addComment({
-          modelName: ModelMap[SUBAPP_CODES.ticketing]!,
-          userId: user.id,
-          workspaceUserId: workspaceUserId,
-          recordId: newTicket.id,
-          subject: `Record Updated by ${user.simpleFullName}`,
-          messageBody: {title: 'Record updated', tracks: tracks, tags: []},
-          messageType: MAIL_MESSAGE_TYPE.notification,
-          client: sideEffectClient,
-          trackingField: 'publicBody',
-          commentField: 'note',
-        });
-      }
-    } catch (e) {
-      console.log('Error adding comment');
-      console.error(e);
-    }
-
-    await Promise.all(
-      contacts.map(async contact => {
-        const tr = getTranslation.bind(null, {
-          locale: contact.localization?.code || DEFAULT_LOCALE,
-          tenant: tenant.id,
-        });
-        await notifyUser({
-          userId: contact.id,
-          tenantId: tenant.id,
-          client: sideEffectClient,
-          workspaceURL,
-          payload: {
-            title: await tr('{0} updated a ticket', user.simpleFullName ?? ''),
-            body: await tr(
-              '{0} updated a ticket: {1}',
-              user.simpleFullName ?? '',
-              String(newTicket.name),
-            ),
-            url: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-            tag: NotificationTag.ticketUpdate(newTicket.id),
-          },
-        });
-      }),
-    );
-
-    try {
-      const reciepients = await getMailRecipients({
-        contacts,
-        client: sideEffectClient,
-        workspaceURL,
-      });
-      if (reciepients.length) {
-        await sendTrackMail({
-          author: user.simpleFullName || '',
-          type: 'update',
-          tracks,
-          projectName: newTicket.project?.name || '',
-          ticketName: newTicket.name,
-          ticketLink: `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${newTicket.project?.id}/tickets/${newTicket.id}`,
-          reciepients,
-          tenant: tenant.id,
-        });
-      }
-    } catch (e) {
-      console.error('Error sending tracking email: ');
-      console.error(e);
-    }
-  });
-  return newTicket;
+  return {ticket: newTicket, tracks, contacts};
 }
 
 export async function getAllTicketCount(props: {

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/mail.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/mail.ts
@@ -38,7 +38,7 @@ export async function sendCommentMail(props: {
   const note = sanitizeHtml(comment.note || '');
   const parentNote = sanitizeHtml(parentComment?.note || '');
 
-  reciepients.forEach(async partner => {
+  for (const partner of reciepients) {
     const t = getTranslation.bind(null, {
       locale: partner.localization?.code || DEFAULT_LOCALE,
       tenant,
@@ -97,7 +97,7 @@ export async function sendCommentMail(props: {
       to: partner.emailAddress?.address,
       html: doc,
     });
-  });
+  }
 }
 
 export async function sendTrackMail(props: {
@@ -126,7 +126,7 @@ export async function sendTrackMail(props: {
     return;
   }
 
-  reciepients.forEach(async partner => {
+  for (const partner of reciepients) {
     const t = getTranslation.bind(null, {
       locale: partner.localization?.code || DEFAULT_LOCALE,
       tenant,
@@ -180,7 +180,7 @@ export async function sendTrackMail(props: {
       to: partner.emailAddress?.address,
       html: doc,
     });
-  });
+  }
 }
 
 async function generateHTML(body: {

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/mail.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/mail.ts
@@ -37,67 +37,80 @@ export async function sendCommentMail(props: {
 
   const note = sanitizeHtml(comment.note || '');
   const parentNote = sanitizeHtml(parentComment?.note || '');
+  const parentAuthor =
+    parentComment?.partner?.simpleFullName ||
+    parentComment?.partner?.name ||
+    parentComment?.createdBy?.fullName;
 
-  for (const partner of reciepients) {
-    const t = getTranslation.bind(null, {
-      locale: partner.localization?.code || DEFAULT_LOCALE,
-      tenant,
-    });
+  const results = await Promise.allSettled(
+    reciepients.map(async partner => {
+      const t = getTranslation.bind(null, {
+        locale: partner.localization?.code || DEFAULT_LOCALE,
+        tenant,
+      });
 
-    const subject = await t(
-      'New comment by {0}',
-      comment.partner?.simpleFullName || comment.partner?.name || '',
-    );
-    const title = subject;
+      const subject = await t(
+        'New comment by {0}',
+        comment.partner?.simpleFullName || comment.partner?.name || '',
+      );
+      const title = subject;
 
-    const content = html`<p style="margin: 0 0 8px 0;">
-        <strong>${await t('Comment left by')}:</strong>
-        <span style="color: #1e40af;"
-          >${comment.partner?.simpleFullName ?? comment.partner?.name}</span
-        >
-      </p>
-      ${parentComment
-        ? html`<div
-              style="border-left: 4px solid #1e40af;  margin: 12px 0;  border-radius: 4px;">
-              <div style="background-color: #ecfdf5; padding-left: 12px;">
-                <p
-                  style="margin: 0 0 4px 0; font-weight: bold; color: #0f172a;">
-                  ${parentComment.partner?.simpleFullName ||
-                  parentComment.partner?.name ||
-                  parentComment.createdBy?.fullName}
-                </p>
-                <p
-                  style="margin: 0; color: #374151; display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis;">
-                  ${parentNote}
-                </p>
+      const content = html`<p style="margin: 0 0 8px 0;">
+          <strong>${await t('Comment left by')}:</strong>
+          <span style="color: #1e40af;"
+            >${comment.partner?.simpleFullName ?? comment.partner?.name}</span
+          >
+        </p>
+        ${parentComment
+          ? html`<div
+                style="border-left: 4px solid #1e40af;  margin: 12px 0;  border-radius: 4px;">
+                <div style="background-color: #ecfdf5; padding-left: 12px;">
+                  <p
+                    style="margin: 0 0 4px 0; font-weight: bold; color: #0f172a;">
+                    ${parentAuthor}
+                  </p>
+                  <p
+                    style="margin: 0; color: #374151; display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis;">
+                    ${parentNote}
+                  </p>
+                </div>
+                <div
+                  style="margin-left: 20px; padding-left: 12px; margin-top: 6px;">
+                  <p style="margin: 0; color: #111827;">${note}</p>
+                </div>
               </div>
-              <div
-                style="margin-left: 20px; padding-left: 12px; margin-top: 6px;">
-                <p style="margin: 0; color: #111827;">${note}</p>
-              </div>
-            </div>
             `
-        : html`<div
-              style="border-left: 4px solid #1e40af; padding-left: 12px; margin: 12px 0; background-color: #f9fafb;">
-              <p style="margin: 0; color: #111827;">${note}</p>
-            </div>`}
+          : html`<div
+                style="border-left: 4px solid #1e40af; padding-left: 12px; margin: 12px 0; background-color: #f9fafb;">
+                <p style="margin: 0; color: #111827;">${note}</p>
+              </div>`}
   `.trim();
 
-    const doc = await generateHTML({
-      projectName,
-      ticketName,
-      content,
-      ticketLink,
-      title,
-      t,
-    });
+      const doc = await generateHTML({
+        projectName,
+        ticketName,
+        content,
+        ticketLink,
+        title,
+        t,
+      });
 
-    await mailService.notify({
-      subject,
-      to: partner.emailAddress?.address,
-      html: doc,
-    });
-  }
+      await mailService.notify({
+        subject,
+        to: partner.emailAddress?.address,
+        html: doc,
+      });
+    }),
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(
+        `Failed to send comment mail to ${reciepients[index].emailAddress?.address}:`,
+        result.reason,
+      );
+    }
+  });
 }
 
 export async function sendTrackMail(props: {
@@ -126,61 +139,73 @@ export async function sendTrackMail(props: {
     return;
   }
 
-  for (const partner of reciepients) {
-    const t = getTranslation.bind(null, {
-      locale: partner.localization?.code || DEFAULT_LOCALE,
-      tenant,
-    });
+  const results = await Promise.allSettled(
+    reciepients.map(async partner => {
+      const t = getTranslation.bind(null, {
+        locale: partner.localization?.code || DEFAULT_LOCALE,
+        tenant,
+      });
 
-    const subject = await t(
-      type === 'create' ? 'Ticket Created by {0}' : 'Ticket Updated by {0}',
-      author,
-    );
-    const title = subject;
-    const content = html`<ul style="list-style: none; padding: 0; margin: 0;">
-        ${(
-          await Promise.all(
-            tracks.map(async ({title, oldValue, value}, index) => {
-              if (title === 'comment.note') return '';
-              const isLast = index === tracks.length - 1;
-              return html`<li
-                  style=" display: flex; align-items: center; padding: 12px 0; font-size: 14px; color: #4a5568; ${!isLast
-                    ? 'border-bottom: 1px solid #e2e8f0;'
-                    : ''}">
-                  <span style=" font-weight: 600; color: #2d3748; "
-                    >${await t(title)}</span
-                  >
-                  <span
-                    style=" color: #38a169; font-weight: 600; margin-left: auto; display: flex; align-items: center; ">
-                    ${oldValue
-                      ? html`<span
-                            style=" color: #e53e3e; text-decoration: line-through; margin-right: 6px; font-weight: 600; "
-                            >${await t(oldValue)}</span
-                          >&rArr;`
-                      : ''}
-                    ${await t(value)}
-                  </span>
-                </li>`;
-            }),
-          )
-        ).join('')}
-      </ul>`;
+      const subject =
+        type === 'create'
+          ? await t('Ticket Created by {0}', author)
+          : await t('Ticket Updated by {0}', author);
+      const title = subject;
+      const content = html`<ul style="list-style: none; padding: 0; margin: 0;">
+          ${(
+            await Promise.all(
+              tracks.map(async ({title, oldValue, value}, index) => {
+                if (title === 'comment.note') return '';
+                const isLast = index === tracks.length - 1;
+                const separatorStyle = isLast
+                  ? ''
+                  : 'border-bottom: 1px solid #e2e8f0;';
+                const oldValueHtml = oldValue
+                  ? html`<span
+                        style=" color: #e53e3e; text-decoration: line-through; margin-right: 6px; font-weight: 600; "
+                        >${await t(oldValue)}</span
+                      >&rArr;`
+                  : '';
+                return html`<li
+                    style=" display: flex; align-items: center; padding: 12px 0; font-size: 14px; color: #4a5568; ${separatorStyle}">
+                    <span style=" font-weight: 600; color: #2d3748; "
+                      >${await t(title)}</span
+                    >
+                    <span
+                      style=" color: #38a169; font-weight: 600; margin-left: auto; display: flex; align-items: center; ">
+                      ${oldValueHtml} ${await t(value)}
+                    </span>
+                  </li>`;
+              }),
+            )
+          ).join('')}
+        </ul>`;
 
-    const doc = await generateHTML({
-      title,
-      projectName,
-      ticketName,
-      ticketLink,
-      content,
-      t,
-    });
+      const doc = await generateHTML({
+        title,
+        projectName,
+        ticketName,
+        ticketLink,
+        content,
+        t,
+      });
 
-    await mailService.notify({
-      subject,
-      to: partner.emailAddress?.address,
-      html: doc,
-    });
-  }
+      await mailService.notify({
+        subject,
+        to: partner.emailAddress?.address,
+        html: doc,
+      });
+    }),
+  );
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(
+        `Failed to send track mail to ${reciepients[index].emailAddress?.address}:`,
+        result.reason,
+      );
+    }
+  });
 }
 
 async function generateHTML(body: {

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/notify.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/utils/notify.ts
@@ -1,0 +1,142 @@
+// ---- CORE IMPORTS ---- //
+import {MAIL_MESSAGE_TYPE, type Track} from '@/comments';
+import {addComment} from '@/comments/orm';
+import {ModelMap, SUBAPP_CODES} from '@/constants';
+import type {Client} from '@/goovee/.generated/client';
+import {DEFAULT_LOCALE} from '@/lib/core/locale';
+import {getTranslation} from '@/lib/core/locale/server';
+import {notifyUser} from '@/pwa/utils';
+import {NotificationTag} from '@/pwa/tags';
+import type {ID} from '@/types';
+
+// ---- LOCAL IMPORTS ---- //
+import type {UserCtx} from '../orm/helpers';
+import {getMailRecipients} from '../orm/mail';
+import {sendTrackMail} from './mail';
+
+/*
+ * Background side effects of a ticket mutation: tracking comment, push
+ * notifications and subscription mails. Actions schedule this with after()
+ * once the mutation has committed.
+ */
+export async function notifyTicketChange({
+  type,
+  ticket,
+  tracks,
+  contacts,
+  user,
+  workspaceUserId,
+  workspaceURL,
+  tenantId,
+  client,
+}: {
+  type: 'create' | 'update';
+  ticket: {
+    id: string;
+    name: string;
+    project: {id: string; name: string | null} | null;
+  };
+  tracks: Track[];
+  contacts: Array<{id: string; localization: {code: string | null} | null}>;
+  user: UserCtx;
+  workspaceUserId?: ID;
+  workspaceURL: string;
+  tenantId: string;
+  client: Client;
+}): Promise<void> {
+  const ticketLink = `${workspaceURL}/${SUBAPP_CODES.ticketing}/projects/${ticket.project?.id}/tickets/${ticket.id}`;
+
+  try {
+    if (workspaceUserId) {
+      await addComment({
+        modelName: ModelMap[SUBAPP_CODES.ticketing]!,
+        userId: user.id,
+        workspaceUserId,
+        recordId: ticket.id,
+        subject:
+          type === 'create'
+            ? `Record Created by ${user.simpleFullName}`
+            : `Record Updated by ${user.simpleFullName}`,
+        messageBody: {
+          title: type === 'create' ? 'Record created' : 'Record updated',
+          tracks,
+          tags: [],
+        },
+        messageType: MAIL_MESSAGE_TYPE.notification,
+        client,
+        trackingField: 'publicBody',
+        commentField: 'note',
+      });
+    }
+  } catch (e) {
+    console.error('Error adding comment');
+    console.error(e);
+  }
+
+  const notifyResults = await Promise.allSettled(
+    contacts.map(async contact => {
+      const tr = getTranslation.bind(null, {
+        locale: contact.localization?.code || DEFAULT_LOCALE,
+        tenant: tenantId,
+      });
+      await notifyUser({
+        userId: contact.id,
+        tenantId,
+        client,
+        workspaceURL,
+        payload: {
+          title:
+            type === 'create'
+              ? await tr('{0} created a new ticket', user.simpleFullName ?? '')
+              : await tr('{0} updated a ticket', user.simpleFullName ?? ''),
+          body:
+            type === 'create'
+              ? await tr(
+                  '{0} created a new ticket: {1}',
+                  user.simpleFullName ?? '',
+                  ticket.name,
+                )
+              : await tr(
+                  '{0} updated a ticket: {1}',
+                  user.simpleFullName ?? '',
+                  ticket.name,
+                ),
+          url: ticketLink,
+          tag: NotificationTag.ticketUpdate(ticket.id),
+        },
+      });
+    }),
+  );
+
+  notifyResults.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error(
+        `Failed to notify contact ${contacts[index].id}:`,
+        result.reason,
+      );
+    }
+  });
+
+  try {
+    const reciepients = await getMailRecipients({
+      contacts,
+      client,
+      workspaceURL,
+    });
+    if (reciepients.length) {
+      await sendTrackMail({
+        author: user.simpleFullName || '',
+        type,
+        tracks,
+        projectName: ticket.project?.name || '',
+        ticketName: ticket.name,
+        ticketLink,
+        reciepients,
+        tenant: tenantId,
+      });
+    }
+  } catch (e) {
+    console.error('Error sending tracking email: ');
+    console.error(e);
+  }
+}

--- a/app/[tenant]/[workspace]/account/(ee)/members/invite/action.ts
+++ b/app/[tenant]/[workspace]/account/(ee)/members/invite/action.ts
@@ -3,6 +3,7 @@
 import {z} from 'zod';
 import {headers} from 'next/headers';
 import {revalidatePath} from 'next/cache';
+import {after} from 'next/server';
 
 // ---- CORE IMPORTS ---- //
 import {getSession} from '@/auth';
@@ -239,31 +240,37 @@ export async function sendInvites({
   function sendMail({email, link, subject}: any) {
     const mailService = NotificationManager.getService(NotificationType.mail);
 
-    if (mailConfig && isValidMailConfig(mailConfig)) {
-      const {template} = mailConfig;
+    after(async () => {
+      try {
+        if (mailConfig && isValidMailConfig(mailConfig)) {
+          const {template} = mailConfig;
 
-      mailService?.notify({
-        to: email,
-        subject: template?.subject || 'Greetings from Goovee',
-        html: replacePlaceholders({
-          content: template?.content,
-          values: {
-            context: {
-              link,
+          await mailService?.notify({
+            to: email,
+            subject: template?.subject || 'Greetings from Goovee',
+            html: replacePlaceholders({
+              content: template?.content,
+              values: {
+                context: {
+                  link,
+                  email,
+                },
+              },
+            }),
+          });
+        } else {
+          await mailService?.notify(
+            inviteTemplate({
+              subject,
               email,
-            },
-          },
-        }),
-      });
-    } else {
-      mailService?.notify(
-        inviteTemplate({
-          subject,
-          email,
-          link,
-        }),
-      );
-    }
+              link,
+            }),
+          );
+        }
+      } catch (err) {
+        console.error('[INVITE] Failed to send invite mail', err);
+      }
+    });
   }
 
   for (const email of emailAddresses) {

--- a/app/api/webhooks/hubpisp/[resourceId]/route.ts
+++ b/app/api/webhooks/hubpisp/[resourceId]/route.ts
@@ -206,6 +206,7 @@ export async function POST(
     client,
     tenantId,
     config,
+    deferNotifications: true,
   });
 
   if (!isTerminal) {

--- a/app/api/webhooks/notifications/route.ts
+++ b/app/api/webhooks/notifications/route.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import sanitizeHtml from 'sanitize-html';
-import {NextResponse} from 'next/server';
+import {NextResponse, after} from 'next/server';
 import {z} from 'zod';
 
 import {manager} from '@/tenant';
@@ -170,7 +170,7 @@ async function sendMail({
   const html =
     mail?.body || (await notificationTemplate({user, tenantId, app, entity}));
 
-  mailService?.notify({
+  await mailService?.notify({
     to: user.email,
     subject:
       mail?.subject ||
@@ -205,7 +205,7 @@ async function sendSystemNotification({
   };
   client: Client;
 }) {
-  notifyUser({
+  await notifyUser({
     userId: user.id,
     tenantId,
     workspaceURL: workspace.url,
@@ -254,19 +254,26 @@ async function sendNotifications(data: {
       client,
     });
 
-    processBatch(subscribers, async ({user, entity}) => {
-      sendMail({user, tenantId, mail, entity, app});
-      sendSystemNotification({
-        user,
-        tenantId,
-        mail,
-        entity,
-        app,
-        workspace,
-        client,
-      });
+    await processBatch(subscribers, async ({user, entity}) => {
+      await Promise.all([
+        sendMail({user, tenantId, mail, entity, app}),
+        sendSystemNotification({
+          user,
+          tenantId,
+          mail,
+          entity,
+          app,
+          workspace,
+          client,
+        }),
+      ]);
     });
-  } catch (err) {}
+  } catch (err) {
+    console.error(
+      '[NOTIFICATIONS] Failed to process webhook notifications',
+      err,
+    );
+  }
 }
 
 const FIVE_MINUTES_MS = 5 * 60 * 1000;
@@ -348,15 +355,17 @@ export async function POST(request: Request) {
     return response('Invalid App', 401);
   }
 
-  sendNotifications({
-    tenantId,
-    code,
-    recordId: String(record.id),
-    mail,
-    client,
-    workspace,
-    app,
-  });
+  after(() =>
+    sendNotifications({
+      tenantId,
+      code,
+      recordId: String(record.id),
+      mail,
+      client,
+      workspace,
+      app,
+    }),
+  );
 
   return response('Success', 200);
 }

--- a/app/api/webhooks/notifications/route.ts
+++ b/app/api/webhooks/notifications/route.ts
@@ -255,18 +255,26 @@ async function sendNotifications(data: {
     });
 
     await processBatch(subscribers, async ({user, entity}) => {
-      await Promise.all([
-        sendMail({user, tenantId, mail, entity, app}),
-        sendSystemNotification({
-          user,
-          tenantId,
-          mail,
-          entity,
-          app,
-          workspace,
-          client,
-        }),
-      ]);
+      try {
+        await Promise.all([
+          sendMail({user, tenantId, mail, entity, app}),
+          sendSystemNotification({
+            user,
+            tenantId,
+            mail,
+            entity,
+            app,
+            workspace,
+            client,
+          }),
+        ]);
+      } catch (err) {
+        console.error(
+          '[NOTIFICATIONS] Failed to notify subscriber',
+          user.email,
+          err,
+        );
+      }
     });
   } catch (err) {
     console.error(

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -1,5 +1,5 @@
 import {experimental_taintUniqueValue} from 'react';
-import {NextResponse} from 'next/server';
+import {NextResponse, after} from 'next/server';
 import {headers} from 'next/headers';
 import Stripe from 'stripe';
 
@@ -255,12 +255,14 @@ export async function POST(req: Request) {
 
             notifyPaymentUpdate(source, sourceId, paymentContext.id);
             if (paymentContext.payer) {
-              notifyInvoicePaymentSuccess({
-                invoiceId: sourceId,
-                payer: paymentContext.payer,
-                tenantId,
-                client,
-              });
+              after(() =>
+                notifyInvoicePaymentSuccess({
+                  invoiceId: sourceId,
+                  payer: paymentContext.payer!,
+                  tenantId,
+                  client,
+                }),
+              );
             }
 
             break;

--- a/app/api/webhooks/up2pay/route.ts
+++ b/app/api/webhooks/up2pay/route.ts
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 
-import {NextResponse} from 'next/server';
+import {NextResponse, after} from 'next/server';
 
 // ---- CORE IMPORTS ---- //
 import {manager} from '@/tenant';
@@ -34,16 +34,17 @@ function forwardToLegacy(request: Request): boolean {
   // so the legacy ERP receives exactly what Up2Pay sent and can verify its own signature.
   const forwardUrl = `${legacyUrl}${new URL(request.url).search}`;
 
-  fetch(forwardUrl, {method: 'GET'})
-    .then(res =>
+  after(async () => {
+    try {
+      const res = await fetch(forwardUrl, {method: 'GET'});
       console.log('[UP2PAY][WEBHOOK] Forwarded to legacy ERP', {
         status: res.status,
         forwardUrl,
-      }),
-    )
-    .catch(err =>
-      console.error('[UP2PAY][WEBHOOK] Legacy forward failed', {error: err}),
-    );
+      });
+    } catch (err) {
+      console.error('[UP2PAY][WEBHOOK] Legacy forward failed', {error: err});
+    }
+  });
 
   return true;
 }
@@ -244,12 +245,14 @@ export async function GET(request: Request) {
       }
 
       if (paymentContext.payer) {
-        notifyInvoicePaymentSuccess({
-          invoiceId: entityId,
-          payer: paymentContext.payer,
-          tenantId,
-          client,
-        });
+        after(() =>
+          notifyInvoicePaymentSuccess({
+            invoiceId: entityId,
+            payer: paymentContext.payer!,
+            tenantId,
+            client,
+          }),
+        );
       }
       break;
     }

--- a/changelogs/unreleased/112763.json
+++ b/changelogs/unreleased/112763.json
@@ -1,0 +1,14 @@
+{
+  "title": "Schedule background side effects with next/server after()",
+  "type": "change",
+  "description": "Replace fire-and-forget promise chains with after() across server actions and API routes. Fixes async forEach in ticketing mail utilities, uses a background client for deferred ticket operations to avoid closed-transaction errors, and adds error handling to all background tasks.",
+  "scope": [
+    "core",
+    "events",
+    "forum",
+    "news",
+    "quotations",
+    "ticketing",
+    "invoices"
+  ]
+}

--- a/changelogs/unreleased/112763.json
+++ b/changelogs/unreleased/112763.json
@@ -1,7 +1,7 @@
 {
   "title": "Schedule background side effects with next/server after()",
   "type": "change",
-  "description": "Replace fire-and-forget promise chains with after() across server actions and API routes. Fixes async forEach in ticketing mail utilities, uses a background client for deferred ticket operations to avoid closed-transaction errors, and adds error handling to all background tasks.",
+  "description": "Replace fire-and-forget promise chains with after() across server actions and API routes. Fixes async forEach in ticketing mail utilities, schedules ticket notifications only after the mutation has committed, and adds error handling to all background tasks.",
   "scope": [
     "core",
     "events",

--- a/lib/core/auth/credentials.ts
+++ b/lib/core/auth/credentials.ts
@@ -1,6 +1,7 @@
 import {BetterAuthPlugin, defineErrorCodes} from 'better-auth';
 import {APIError, createAuthEndpoint} from 'better-auth/api';
 import {setSessionCookie} from 'better-auth/cookies';
+import {after} from 'next/server';
 import {z} from 'zod';
 
 import {compare, hash} from '@/auth/utils';
@@ -563,18 +564,25 @@ const credentials = {
           const mailService = NotificationManager.getService(
             NotificationType.mail,
           );
-          createOTP({
-            entity: email,
-            scope: Scope.ResetPassword,
-            client,
-            force: true,
-          }).then(result => {
-            result?.otp &&
-              mailService?.notify({
-                subject: 'Goovee Password Reset',
-                to: email,
-                html: resetPasswordEmailHTML({email, otp: result.otp, link}),
+          after(async () => {
+            try {
+              const result = await createOTP({
+                entity: email,
+                scope: Scope.ResetPassword,
+                client,
+                force: true,
               });
+
+              if (result?.otp) {
+                await mailService?.notify({
+                  subject: 'Goovee Password Reset',
+                  to: email,
+                  html: resetPasswordEmailHTML({email, otp: result.otp, link}),
+                });
+              }
+            } catch (err) {
+              console.error('[AUTH] Failed to send password reset mail', err);
+            }
           });
         }
 

--- a/lib/core/otp/actions/index.ts
+++ b/lib/core/otp/actions/index.ts
@@ -1,4 +1,5 @@
 // ---- CORE IMPORTS ---- //
+import {after} from 'next/server';
 import {getTranslation} from '@/locale/server';
 import NotificationManager, {NotificationType} from '@/notification';
 import {
@@ -116,33 +117,38 @@ export async function generateOTP({
     }
 
     const mailService = NotificationManager.getService(NotificationType.mail);
+    if (!result?.otp) return;
 
-    if (mailConfig && isValidMailConfig(mailConfig)) {
-      const {template} = mailConfig;
+    after(async () => {
+      try {
+        if (mailConfig && isValidMailConfig(mailConfig)) {
+          const {template} = mailConfig;
 
-      result?.otp &&
-        mailService?.notify({
-          to: email,
-          subject: template?.subject || 'Greetings from Goovee',
-          html: replacePlaceholders({
-            content: template?.content,
-            values: {
-              context: {
-                otp: result.otp,
-                email,
+          await mailService?.notify({
+            to: email,
+            subject: template?.subject || 'Greetings from Goovee',
+            html: replacePlaceholders({
+              content: template?.content,
+              values: {
+                context: {
+                  otp: result.otp,
+                  email,
+                },
               },
-            },
-          }),
-        });
-    } else {
-      result?.otp &&
-        mailService?.notify(
-          otpTemplate({
-            email,
-            otp: result.otp,
-          }),
-        );
-    }
+            }),
+          });
+        } else {
+          await mailService?.notify(
+            otpTemplate({
+              email,
+              otp: result.otp,
+            }),
+          );
+        }
+      } catch (err) {
+        console.error('[OTP] Failed to send OTP mail', err);
+      }
+    });
   } catch (err) {
     return error(
       await getTranslation(

--- a/lib/core/payment/hubpisp/process.ts
+++ b/lib/core/payment/hubpisp/process.ts
@@ -1,5 +1,6 @@
 import type {Client} from '@/goovee/.generated/client';
 import type {TenantConfig} from '@/tenant';
+import {after} from 'next/server';
 import {
   markPaymentAsCancelled,
   markPaymentAsFailed,
@@ -28,6 +29,7 @@ export async function applyTransactionStatus({
   client,
   tenantId,
   config,
+  deferNotifications = false,
 }: {
   paymentContext: PaymentContext;
   transactionStatus: string;
@@ -35,6 +37,7 @@ export async function applyTransactionStatus({
   client: Client;
   tenantId: string;
   config: TenantConfig;
+  deferNotifications?: boolean;
 }): Promise<boolean> {
   switch (transactionStatus) {
     case HUBPISP_TRANSACTION_STATUS.CANC:
@@ -75,7 +78,13 @@ export async function applyTransactionStatus({
       return true;
 
     case HUBPISP_TRANSACTION_STATUS.ACSC:
-      await processAcscPayment({paymentContext, client, tenantId, config});
+      await processAcscPayment({
+        paymentContext,
+        client,
+        tenantId,
+        config,
+        deferNotifications,
+      });
       return true;
 
     default:
@@ -88,11 +97,13 @@ export async function processAcscPayment({
   client,
   tenantId,
   config,
+  deferNotifications = false,
 }: {
   paymentContext: PaymentContext;
   client: Client;
   tenantId: string;
   config: TenantConfig;
+  deferNotifications?: boolean;
 }): Promise<void> {
   const source = paymentContext.data?.source;
   const entityId = paymentContext.data?.id;
@@ -121,12 +132,19 @@ export async function processAcscPayment({
       }
 
       if (paymentContext.payer) {
-        notifyInvoicePaymentSuccess({
-          invoiceId: entityId,
-          payer: paymentContext.payer,
-          tenantId,
-          client,
-        });
+        const notifyPaymentSuccess = () =>
+          notifyInvoicePaymentSuccess({
+            invoiceId: entityId,
+            payer: paymentContext.payer!,
+            tenantId,
+            client,
+          });
+
+        if (deferNotifications) {
+          after(notifyPaymentSuccess);
+        } else {
+          await notifyPaymentSuccess();
+        }
       }
       break;
     }

--- a/lib/core/pwa/utils.ts
+++ b/lib/core/pwa/utils.ts
@@ -123,69 +123,73 @@ export async function notifyUser({
   }
 
   // 3. Send the real-time push notification to all active devices
-  const subscriptions = await client.pushSubscription.find({
-    where: {partner: {id: userId}},
-    select: {
-      id: true,
-      endpoint: true,
-      p256dh: true,
-      auth: true,
-      version: true,
-      expiresAt: true,
-    },
-  });
+  try {
+    const subscriptions = await client.pushSubscription.find({
+      where: {partner: {id: userId}},
+      select: {
+        id: true,
+        endpoint: true,
+        p256dh: true,
+        auth: true,
+        version: true,
+        expiresAt: true,
+      },
+    });
 
-  if (!subscriptions?.length) return;
+    if (!subscriptions?.length) return;
 
-  const pushPayload: NotificationPayload = {
-    ...payload,
-    title: pushTitle,
-    tenantId,
-    workspaceURL,
-    notification: dbNotification,
-  };
+    const pushPayload: NotificationPayload = {
+      ...payload,
+      title: pushTitle,
+      tenantId,
+      workspaceURL,
+      notification: dbNotification,
+    };
 
-  await Promise.all(
-    subscriptions.map(async sub => {
-      if (!sub.endpoint || !sub.p256dh || !sub.auth) return;
+    await Promise.all(
+      subscriptions.map(async sub => {
+        if (!sub.endpoint || !sub.p256dh || !sub.auth) return;
 
-      if (sub.expiresAt && sub.expiresAt < new Date()) {
-        await client.pushSubscription.delete({
-          id: sub.id,
-          version: sub.version,
-        });
-        return;
-      }
-
-      const result = await sendNotification(
-        {
-          endpoint: sub.endpoint,
-          keys: {
-            p256dh: sub.p256dh,
-            auth: sub.auth,
-          },
-        },
-        pushPayload,
-      );
-
-      if (result.error) {
-        if (result.message === 'expired') {
+        if (sub.expiresAt && sub.expiresAt < new Date()) {
           await client.pushSubscription.delete({
             id: sub.id,
             version: sub.version,
           });
-        } else {
-          console.error('Error sending notification:', {
-            result,
-            subId: sub.id,
-            notificationId: pushPayload.notification?.id,
-          });
+          return;
         }
-      }
 
-      return result;
-    }),
-  );
+        const result = await sendNotification(
+          {
+            endpoint: sub.endpoint,
+            keys: {
+              p256dh: sub.p256dh,
+              auth: sub.auth,
+            },
+          },
+          pushPayload,
+        );
+
+        if (result.error) {
+          if (result.message === 'expired') {
+            await client.pushSubscription.delete({
+              id: sub.id,
+              version: sub.version,
+            });
+          } else {
+            console.error('Error sending notification:', {
+              result,
+              subId: sub.id,
+              notificationId: pushPayload.notification?.id,
+            });
+          }
+        }
+
+        return result;
+      }),
+    );
+  } catch (error) {
+    console.error('Failed to send push notification:', {userId, error});
+  }
 }
 
 export default webpush;


### PR DESCRIPTION
https://redmine.axelor.com/issues/112763

- Replace fire-and-forget and floating promise chains with after()
- Fix async iteration in ticketing mail utilities
- Use a background client for deferred ticket operations
- Add error handling for all background tasks