### PR TITLE
fix(comments): cap concurrent uploads and limit attachments to 5 (#113763)

### DIFF
--- a/lib/core/comments/constants/constant.ts
+++ b/lib/core/comments/constants/constant.ts
@@ -1,5 +1,8 @@
 export const MAX_FILE_SIZE = 20000000; // 20 MB
 
+/* Maximum number of attachments allowed on a single comment. */
+export const MAX_ATTACHMENTS = 5;
+
 /* Staged-upload purpose under which comment attachments are pre-uploaded
  * (registered in lib/core/upload/staged-upload.ts) and redeemed at creation. */
 export const COMMENT_ATTACHMENT_PURPOSE = 'comments:attachment';

--- a/lib/core/comments/ui/comment-input/comments-input.tsx
+++ b/lib/core/comments/ui/comment-input/comments-input.tsx
@@ -27,7 +27,11 @@ import {cn} from '@/utils/css';
 import {getFileSizeText} from '@/utils/files';
 
 import type {CommentData, CreateProps} from '../../types';
-import {COMMENT_ATTACHMENT_PURPOSE, MAX_FILE_SIZE} from '../../constants';
+import {
+  COMMENT_ATTACHMENT_PURPOSE,
+  MAX_ATTACHMENTS,
+  MAX_FILE_SIZE,
+} from '../../constants';
 
 /*
  * Client-side form shape: each attachment row references its staged upload by
@@ -127,7 +131,18 @@ export function CommentInput({
   });
 
   const onDrop = (acceptedFiles: File[]) => {
-    acceptedFiles.forEach(file => {
+    const remaining = MAX_ATTACHMENTS - fields.length;
+    const accepted = acceptedFiles.slice(0, Math.max(0, remaining));
+    if (accepted.length < acceptedFiles.length) {
+      toast({
+        variant: 'destructive',
+        title: i18n.t(
+          'You can attach up to {0} files',
+          String(MAX_ATTACHMENTS),
+        ),
+      });
+    }
+    accepted.forEach(file => {
       const {ids} = upload(file, {purpose: COMMENT_ATTACHMENT_PURPOSE});
       append({
         title: '',

--- a/lib/core/comments/utils/validators.ts
+++ b/lib/core/comments/utils/validators.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 
 import {uploadTokenSchema} from '@/lib/core/upload/validators';
 
-import {SORT_TYPE} from '../constants';
+import {MAX_ATTACHMENTS, SORT_TYPE} from '../constants';
 
 const attachmentSchema = z.object({
   title: z.string(),
@@ -14,7 +14,9 @@ const attachmentSchema = z.object({
 
 export const formSchema = z
   .object({
-    attachments: z.array(attachmentSchema),
+    attachments: z.array(attachmentSchema).max(MAX_ATTACHMENTS, {
+      error: `A comment can have at most ${MAX_ATTACHMENTS} attachments`,
+    }),
     text: z.string().optional(),
   })
   .superRefine((data, ctx) => {

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1016,6 +1016,7 @@
   "You are signed in as {0}. Sign out to access via token.": "You are signed in as {0}. Sign out to access via token.",
   "You are trying to create an account for an existing company, please contact admin to invite you as a user": "You are trying to create an account for an existing company, please contact admin to invite you as a user",
   "You can add up to {0} files": "You can add up to {0} files",
+  "You can attach up to {0} files": "You can attach up to {0} files",
   "You can only register up to {0} people": "You can only register up to {0} people",
   "You do not have permission to comment": "You do not have permission to comment",
   "You have been registered for an event!": "You have been registered for an event!",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1016,6 +1016,7 @@
   "You are signed in as {0}. Sign out to access via token.": "Vous êtes connecté en tant que {0}. Déconnectez-vous pour accéder via le token.",
   "You are trying to create an account for an existing company, please contact admin to invite you as a user": "Vous essayez de créer un compte pour une société déjà existante, veuillez contacter votre admin",
   "You can add up to {0} files": "Vous pouvez ajouter jusqu'à {0} fichiers",
+  "You can attach up to {0} files": "Vous pouvez joindre jusqu'à {0} fichiers",
   "You can only register up to {0} people": "Vous ne pouvez pas enregistrer plus de {0} people",
   "You do not have permission to comment": "Vous n'avez pas la permission de commenter",
   "You have been registered for an event!": "Vous avez été inscrit à un événement !",


### PR DESCRIPTION
- Comment attachments are staged in a single upload() call so the concurrency limit applies — a few stream at once and the rest queue, instead of every dropped file opening a request simultaneously. On slow connections this avoids many parallel uploads splitting bandwidth and hitting request timeouts.
- A comment is limited to 5 attachments, enforced as files are added and again on the server when the comment is saved.

https://redmine.axelor.com/issues/113763