### PR TITLE
feat(core): record storage type on uploaded files for AOP 8 / AOS 9 (#114307)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/website/common/orm/templates.ts
+++ b/app/[tenant]/[workspace]/(subapps)/website/common/orm/templates.ts
@@ -18,6 +18,7 @@ import type {
   AOSPortalCmsSite,
 } from '@/goovee/.generated/models';
 import type {Client} from '@/goovee/.generated/client';
+import {MetaFileStoreType} from '@/lib/core/upload/file';
 import {getFileSizeText} from '@/utils/files';
 import {xml} from '@/utils/template-string';
 import type {CreateArgs, SelectArg} from '@goovee/orm';
@@ -656,6 +657,7 @@ async function createMetaFile({
     fileType,
     fileSize: buffer.length.toString(),
     sizeText: getFileSizeText(buffer.length),
+    storeType: MetaFileStoreType.LOCAL,
   };
 
   const _metaFile = await client.aOSMetaFile.findOne({

--- a/changelogs/unreleased/114307.json
+++ b/changelogs/unreleased/114307.json
@@ -1,0 +1,6 @@
+{
+  "title": "Record storage type on uploaded files for AOP 8 / AOS 9 support",
+  "type": "feature",
+  "scope": ["core"],
+  "description": "Files uploaded through the portal now record their storage type (local), which AOP 8 / AOS 9 requires; without it those backends reject the upload. No change on AOP 7 / AOS 8."
+}

--- a/goovee/schema/AOSMetaFile.json
+++ b/goovee/schema/AOSMetaFile.json
@@ -27,6 +27,12 @@
       "type": "String",
       "name": "sizeText",
       "column": "file_size_text"
+    },
+    {
+      "type": "Int",
+      "name": "storeType",
+      "column": "store_type",
+      "required": true
     }
   ]
 }

--- a/lib/core/upload/file.ts
+++ b/lib/core/upload/file.ts
@@ -9,6 +9,15 @@ import type {Client} from '@/goovee/.generated/client';
 import {getStoragePath} from '@/storage/index';
 import {getFileSizeText} from '@/utils/files';
 
+/*
+ * AOP MetaFile store backend (meta_file.store_type, NOT NULL since AOP 8.0).
+ * Goovee writes uploads to the local filesystem, so every meta_file row it
+ * creates uses the local store.
+ */
+export enum MetaFileStoreType {
+  LOCAL = 1,
+}
+
 export interface UploadedFile {
   id: string;
   fileName: string;
@@ -97,6 +106,7 @@ export async function createMetaFile(
       fileType,
       fileSize: String(size),
       sizeText: getFileSizeText(size),
+      storeType: MetaFileStoreType.LOCAL,
     },
     select: {id: true, fileName: true, filePath: true, sizeText: true},
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goovee/core",
-  "version": "1.8.0",
+  "version": "2.0.0",
   "private": true,
   "scripts": {
     "dev": "cross-env NODE_ENV=development serwist build && next dev",


### PR DESCRIPTION
https://redmine.axelor.com/issues/114307

Targets the Goovee 2.x line (AOP 8 / AOS 9). `store_type` is required on AOP 8 and absent on AOP 7, so this must merge onto the 2.x line only, never 1.x.