### PR TITLE
fix(shop): restore web-service price lookup for after-login pricing (#114662)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
@@ -41,7 +41,7 @@ async function Category({
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return notFound();
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user,
@@ -104,6 +104,7 @@ async function Category({
     workspace,
     user,
     client,
+    config,
   });
 
   const parentcategories = $cats.filter(c => !c.parent);

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
@@ -45,7 +45,7 @@ export async function generateMetadata(props: {
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return null;
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user: user,
@@ -75,6 +75,7 @@ export async function generateMetadata(props: {
     workspace,
     user,
     client,
+    config,
     categoryids: [$category.id],
   });
 
@@ -117,7 +118,7 @@ async function Product({
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return notFound();
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user,
@@ -147,6 +148,7 @@ async function Product({
     workspace,
     user,
     client,
+    config,
     categoryids: [$category.id],
   });
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
@@ -43,7 +43,7 @@ export async function findProduct({
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return null;
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const categories = await findCategories({
     workspace,
@@ -58,6 +58,7 @@ export async function findProduct({
     workspace,
     user,
     client,
+    config,
     categoryids,
   }).then(clone);
 }

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -274,7 +274,7 @@ export async function findProducts({
   workspace?: PortalWorkspace | Cloned<PortalWorkspace>;
   user?: User;
   client: Client;
-  config?: TenantConfig;
+  config: TenantConfig;
   associateWorkspace?: boolean;
 }) {
   if (!(workspace && workspace.config && client))
@@ -661,7 +661,7 @@ export async function findProduct({
   workspace: PortalWorkspace | Cloned<PortalWorkspace>;
   user?: User;
   client: Client;
-  config?: TenantConfig;
+  config: TenantConfig;
   categoryids?: (string | number)[];
 }) {
   if (!id) {
@@ -694,7 +694,7 @@ export async function findProductBySlug({
   workspace: PortalWorkspace | Cloned<PortalWorkspace>;
   user?: User;
   client: Client;
-  config?: TenantConfig;
+  config: TenantConfig;
   categoryids?: (string | number)[];
 }) {
   if (!slug) {
@@ -746,7 +746,7 @@ export async function findProductsFromWS({
   workspace: PortalWorkspace | Cloned<PortalWorkspace>;
   user?: User;
   productList: Array<{productId: Product['id']}>;
-  config?: TenantConfig;
+  config: TenantConfig;
 }): Promise<WSObject[]> {
   if (!workspace?.config?.company?.id && user && productList && config) {
     return [];

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/service/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/service/index.ts
@@ -41,7 +41,7 @@ export async function createOrder({
 
   const computedProducts = await Promise.all(
     cart.items.map((i: CartItemInput) =>
-      findProduct({id: i.product, workspace, user, client}),
+      findProduct({id: i.product, workspace, user, client, config}),
     ),
   );
 
@@ -138,7 +138,7 @@ export async function requestOrder({
   if (!tenant?.config?.aos?.url) return null;
 
   const {aos} = tenant.config;
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const ws = `${aos.url}/ws/portal/orders/${type}`;
 
@@ -151,7 +151,7 @@ export async function requestOrder({
     const computedProducts = (
       await Promise.all(
         cart.items.map(i =>
-          findProduct({id: i.product, workspace, user, client}),
+          findProduct({id: i.product, workspace, user, client, config}),
         ),
       )
     ).filter(Boolean);

--- a/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
@@ -8,6 +8,7 @@ import {clone} from '@/utils';
 import {workspacePathname} from '@/utils/workspace';
 import {findWorkspace} from '@/orm/workspace';
 import {manager} from '@/tenant';
+import type {TenantConfig} from '@/tenant';
 import type {Client} from '@/goovee/.generated/client';
 import type {User, Category, ComputedProduct} from '@/types';
 import type {PortalWorkspace} from '@/orm/workspace';
@@ -62,10 +63,12 @@ async function Carousel({
 
 async function Featured({
   client,
+  config,
   user,
   workspace,
 }: {
   client: Client;
+  config: TenantConfig;
   user: User | undefined;
   workspace: PortalWorkspace | Cloned<PortalWorkspace>;
 }) {
@@ -82,6 +85,7 @@ async function Featured({
         workspace: workspace!,
         user,
         client,
+        config,
         categoryids: [category.id],
       }).then(clone);
 
@@ -114,7 +118,7 @@ async function Shop({params}: {params: {tenant: string; workspace: string}}) {
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return notFound();
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user,
@@ -138,7 +142,12 @@ async function Shop({params}: {params: {tenant: string; workspace: string}}) {
       </Suspense>
       <div className="container flex flex-col gap-6 mx-auto px-2 mb-4">
         <Suspense fallback={<FeaturedCategoriesSkeleton />}>
-          <Featured workspace={workspace} user={user} client={client} />
+          <Featured
+            workspace={workspace}
+            user={user}
+            client={client}
+            config={config}
+          />
         </Suspense>
       </div>
     </div>

--- a/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata(props: {
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return null;
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user: user,
@@ -64,6 +64,7 @@ export async function generateMetadata(props: {
     workspace,
     user,
     client,
+    config,
     categoryids,
   });
 
@@ -95,7 +96,7 @@ async function Product({
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return notFound();
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user: user,
@@ -116,6 +117,7 @@ async function Product({
     workspace,
     user,
     client,
+    config,
     categoryids,
   });
 

--- a/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/[websitePageSlug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/[websitePageSlug]/page.tsx
@@ -76,7 +76,7 @@ export default async function Page(props: {
   if (!tenant) {
     return <NotFound homePageUrl={`${workspaceURI}/${SUBAPP_CODES.website}`} />;
   }
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const [canUserEditWiki, websitePage] = await Promise.all([
     canEditWiki({userId: user?.id, client}),
@@ -99,6 +99,7 @@ export default async function Page(props: {
     contentLinesChunk = populateLinesByChunk({
       contentLines: websitePage?.contentLines,
       client,
+      config,
       chunkSize: 5,
     });
   }

--- a/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/layout.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/layout.tsx
@@ -84,7 +84,7 @@ export default async function Layout(props: {
   if (!tenant) {
     return <NotFound homePageUrl={`${workspaceURI}/${SUBAPP_CODES.website}`} />;
   }
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const website = await findWebsiteBySlug({
     websiteSlug,
@@ -92,6 +92,7 @@ export default async function Layout(props: {
     workspaceURI,
     user,
     client,
+    config,
     mountTypes: layoutMountTypes,
   });
 

--- a/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/website/[websiteSlug]/page.tsx
@@ -30,7 +30,7 @@ export default async function Layout(props: {
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return notFound();
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const website = await findWebsiteBySlug({
     websiteSlug,
@@ -38,6 +38,7 @@ export default async function Layout(props: {
     workspaceURI,
     user,
     client,
+    config,
   });
 
   if (!website) {

--- a/app/[tenant]/[workspace]/(subapps)/website/api/templates/[mountType]/[websiteSlug]/[websitePageSlug]/[content-id]/[path]/[file-id]/route.ts
+++ b/app/[tenant]/[workspace]/(subapps)/website/api/templates/[mountType]/[websiteSlug]/[websitePageSlug]/[content-id]/[path]/[file-id]/route.ts
@@ -66,7 +66,7 @@ export async function GET(
   if (!tenant) {
     return new NextResponse('Invalid tenant', {status: 401});
   }
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const workspace = await findWorkspace({
     user,
@@ -106,6 +106,7 @@ export async function GET(
     const line = await populateContent({
       line: websitePage.contentLines[0],
       client,
+      config,
       path: stringToPath(path),
     });
     attrs = line?.content?.attrs;
@@ -116,6 +117,7 @@ export async function GET(
       workspaceURI,
       user,
       client,
+      config,
       mountTypes: [mountType],
       path: stringToPath(path),
     });

--- a/app/[tenant]/[workspace]/(subapps)/website/common/action/index.ts
+++ b/app/[tenant]/[workspace]/(subapps)/website/common/action/index.ts
@@ -53,7 +53,7 @@ export async function getLocaleRedirectionURL(
 
   const tenant = await manager.getTenant(tenantId);
   if (!tenant) return {error: true, message: await t('Invalid tenant')};
-  const {client} = tenant;
+  const {client, config} = tenant;
 
   const subapp = await findSubappAccess({
     code: SUBAPP_CODES.website,
@@ -74,6 +74,7 @@ export async function getLocaleRedirectionURL(
     workspaceURI,
     user,
     client,
+    config,
   });
 
   if (!website) {

--- a/app/[tenant]/[workspace]/(subapps)/website/common/orm/website.ts
+++ b/app/[tenant]/[workspace]/(subapps)/website/common/orm/website.ts
@@ -199,6 +199,7 @@ export async function findWebsiteBySlug({
   workspaceURI,
   user,
   client,
+  config,
   mountTypes,
   path,
 }: {
@@ -207,6 +208,7 @@ export async function findWebsiteBySlug({
   workspaceURI: string;
   user?: User;
   client: Client;
+  config: TenantConfig;
   mountTypes?: LayoutMountType[];
   /** @param mounTypes should be an array of single mountType for path to work
    * ex: mountTypes:[ "header" ]
@@ -308,6 +310,7 @@ export async function findWebsiteBySlug({
       modelName: CONTENT_MODEL,
       modelField: CONTENT_MODEL_ATTRS,
       client,
+      config,
       path,
       modelFieldCache,
       modelRecordCache,
@@ -322,6 +325,7 @@ export async function findWebsiteBySlug({
       modelName: CONTENT_MODEL,
       modelField: CONTENT_MODEL_ATTRS,
       client,
+      config,
       path,
       modelFieldCache,
       modelRecordCache,
@@ -524,11 +528,13 @@ async function getRelationalFieldTypeData({
   value,
   modelRecordCache,
   client,
+  config,
 }: {
   field: {targetModel?: string};
   value: any;
   modelRecordCache: Cache;
   client: Client;
+  config: TenantConfig;
 }) {
   const targetModel = field?.targetModel;
 
@@ -562,6 +568,7 @@ async function getRelationalFieldTypeData({
 
     let records = await findModelRecords({
       client,
+      config,
       modelName: targetModel,
       ids: uncachedIds,
     });
@@ -596,6 +603,7 @@ async function getCustomRelationalFieldTypeData({
   jsonModelCache,
   jsonModelRecordCache,
   client,
+  config,
   path,
 }: {
   field: {targetJsonModel?: {name?: string}};
@@ -605,6 +613,7 @@ async function getCustomRelationalFieldTypeData({
   jsonModelCache: Cache;
   jsonModelRecordCache: Cache;
   client: Client;
+  config: TenantConfig;
   path?: string[];
 }) {
   const pathFieldName = path?.[0];
@@ -685,6 +694,7 @@ async function getCustomRelationalFieldTypeData({
                 modelField: JSON_MODEL_ATTRS,
                 jsonModelName: targetJsonModelName,
                 client,
+                config,
                 modelFieldCache,
                 modelRecordCache,
                 jsonModelCache,
@@ -796,6 +806,7 @@ const populateAttributes = async ({
   jsonModelName,
   modelField,
   client,
+  config,
   modelFieldCache,
   modelRecordCache,
   jsonModelCache,
@@ -807,6 +818,7 @@ const populateAttributes = async ({
   jsonModelName?: string;
   modelField: string;
   client: Client;
+  config: TenantConfig;
   modelFieldCache: Cache;
   modelRecordCache: Cache;
   jsonModelCache: Cache;
@@ -870,6 +882,7 @@ const populateAttributes = async ({
       jsonModelCache,
       jsonModelRecordCache,
       client,
+      config,
       path: path?.[1] ? path.slice(1) : undefined,
     });
 
@@ -883,6 +896,7 @@ export async function populateContent({
   line,
   path,
   client,
+  config,
   modelFieldCache = new Cache(),
   modelRecordCache = new Cache(),
   jsonModelCache = new Cache(),
@@ -894,6 +908,7 @@ export async function populateContent({
    */
   path?: string[];
   client: Client;
+  config: TenantConfig;
   modelFieldCache?: Cache;
   modelRecordCache?: Cache;
   jsonModelCache?: Cache;
@@ -910,6 +925,7 @@ export async function populateContent({
         modelName: CONTENT_MODEL,
         modelField: CONTENT_MODEL_ATTRS,
         client,
+        config,
         modelFieldCache,
         modelRecordCache,
         jsonModelCache,
@@ -923,6 +939,7 @@ export async function populateContent({
 export function populateLinesByChunk({
   contentLines,
   client,
+  config,
   path,
   chunkSize,
 }: {
@@ -933,6 +950,7 @@ export function populateLinesByChunk({
   chunkSize?: number;
   contentLines: ContentLine[];
   client: Client;
+  config: TenantConfig;
 }): Promise<ReplacedContentLine[]>[] {
   const jsonModelCache = new Cache();
   const jsonModelRecordCache = new Cache();
@@ -953,6 +971,7 @@ export function populateLinesByChunk({
           populateContent({
             line,
             client,
+            config,
             path,
             modelFieldCache,
             modelRecordCache,
@@ -986,7 +1005,7 @@ async function findModelRecords({
   ids,
 }: {
   client: Client;
-  config?: TenantConfig;
+  config: TenantConfig;
   modelName: string;
   ids: string[];
 }) {

--- a/changelogs/unreleased/114662.json
+++ b/changelogs/unreleased/114662.json
@@ -1,0 +1,6 @@
+{
+  "title": "Fix empty shop catalogue when prices are fetched from the web service after login",
+  "type": "fix",
+  "description": "For workspaces configured to fetch prices from the web service after login, the product listing, product detail, cart, order creation and quotation requests now correctly load products and prices instead of showing an empty catalogue.",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
https://redmine.axelor.com/issues/114662

Restores the tenant config that was dropped when the `tenantId → client` ORM refactor (first shipped 1.7.0) migrated callers to pass only the resolved client. The config carries the web-service URL and credentials, so the functions that call the web service received `undefined` and returned no data.

- **Shop (fix):** `findProducts`/`findProduct`/`findProductBySlug`/`findProductsFromWS` now take a required `config`, and every call site passes `tenant.config`. Workspaces configured to fetch prices from the web service after login showed an empty catalogue; product listing, detail, cart, order creation and quotation requests are all fixed. Behaviour is unchanged for database-priced workspaces.
- **Website (defensive):** threads `config` through the template content-population chain down to the web-service fallback. That path is currently unreachable in practice, so there is no observable behaviour change — included for future correctness.