### PR TITLE
fix(shop): speed up product detail pages, home and product images (#114538)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
@@ -72,11 +72,11 @@ async function Category({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
+  const categories = await findCategories(
+    access.workspace.id,
     user,
-  }).then(clone);
+    client,
+  ).then(clone);
 
   const $cats = categories as Category[];
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
@@ -18,7 +18,10 @@ import {
   ProductView,
   ProductViewSkeleton,
 } from '@/subapps/shop/common/ui/components';
-import {findProductBySlug} from '@/subapps/shop/common/orm/product';
+import {
+  findProductBySlug,
+  findProductMetaBySlug,
+} from '@/subapps/shop/common/orm/product';
 import {getShopConfig} from '@/subapps/shop/common/orm/config';
 import {findCategories} from '@/subapps/shop/common/orm/categories';
 import {
@@ -39,7 +42,6 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const {workspaceURL, tenant: tenantId} = workspacePathname(params);
 
-  const categorySlug = params['category-slug'];
   const productSlug = params['product-slug'];
 
   const access = await ensureAccess({
@@ -52,46 +54,21 @@ export async function generateMetadata(props: {
 
   const {user} = access;
   const {client} = access.tenant;
-  const {config} = access.tenant;
 
-  const workspaceConfig = await getShopConfig(
-    access.workspace.config.id,
-    client,
-  );
-  if (!workspaceConfig) return null;
-
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-    user,
-  }).then(clone);
-
-  const $category =
-    (categories as Category[]).find(c => c.slug === categorySlug) ?? null;
-
-  if (!$category) {
-    return null;
-  }
-
-  const computedProduct = await findProductBySlug({
+  const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
-    workspaceConfig,
     user,
     client,
-    config,
-    categoryids: [$category.id],
   });
 
-  if (!computedProduct?.product) {
+  if (!product) {
     return null;
   }
 
-  const {product} = computedProduct;
-
   return {
-    title: product?.name,
-    description: htmlToNormalString(product?.description ?? ''),
+    title: product.name,
+    description: htmlToNormalString(product.description ?? ''),
   };
 }
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const {workspaceURL, tenant: tenantId} = workspacePathname(params);
 
+  const categorySlug = params['category-slug'];
   const productSlug = params['product-slug'];
 
   const access = await ensureAccess({
@@ -55,11 +56,17 @@ export async function generateMetadata(props: {
   const {user} = access;
   const {client} = access.tenant;
 
+  const categories = await findCategories(access.workspace.id, user, client);
+  const $category =
+    (categories as Category[]).find(c => c.slug === categorySlug) ?? null;
+  if (!$category) return null;
+
   const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
     user,
     client,
+    categoryids: [$category.id],
   });
 
   if (!product) {
@@ -128,11 +135,11 @@ async function Product({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
+  const categories = await findCategories(
+    access.workspace.id,
     user,
-  }).then(clone);
+    client,
+  ).then(clone);
 
   const $category =
     (categories as Category[]).find(c => c.slug === categorySlug) ?? null;

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
@@ -51,11 +51,7 @@ export async function findProduct({
   );
   if (!workspaceConfig) return null;
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-    user,
-  });
+  const categories = await findCategories(access.workspace.id, user, client);
 
   const categoryids = categories.map(c => getcategoryids(c)).flat();
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/categories.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/categories.ts
@@ -1,4 +1,5 @@
 // ---- CORE IMPORTS ---- //
+import {cache} from 'react';
 import {filterPrivate} from '@/orm/filter';
 import type {Cloned} from '@/types/util';
 import type {Client} from '@/goovee/.generated/client';
@@ -35,23 +36,18 @@ function transform($categories: RawCategory[]): Category[] {
   return Object.values(categoriesMap);
 }
 
-export async function findCategories({
-  workspace,
-  client,
-  user,
-  archived,
-}: {
-  workspace: Workspace | Cloned<Workspace>;
-  client: Client;
-  user?: User;
-  archived?: boolean;
-}) {
-  if (!(workspace && client)) return [];
+async function loadCategories(
+  workspaceId: Workspace['id'],
+  user: User | undefined,
+  client: Client,
+  archived?: boolean,
+) {
+  if (!(workspaceId && client)) return [];
 
   const categories = await client.aOSProductCategory.find({
     where: {
       portalWorkspace: {
-        id: workspace.id,
+        id: workspaceId,
       },
       AND: [
         filterPrivate({user}),
@@ -70,6 +66,14 @@ export async function findCategories({
 
   return transform(categories);
 }
+
+/* Request-scoped memoization: several pages call findCategories more than
+   once per request (render plus generateMetadata) for the same workspace
+   category tree. cache() collapses those repeat calls to one DB read.
+   Keying on workspaceId (a primitive) rather than the workspace object
+   ensures the cache hits even when call sites hold differently-cloned
+   workspace references. */
+export const findCategories = cache(loadCategories);
 
 export async function findFeaturedCategories({
   workspace,

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -725,19 +725,22 @@ export async function findProductBySlug({
 
 /**
  * Lightweight product lookup for page metadata (title/description) only.
- * Skips the full pricing/category pipeline of findProductBySlug — a single
- * findOne selecting name + description, gated by the same privacy filter.
+ * Skips the full pricing pipeline of findProductBySlug — a single findOne
+ * selecting name + description, gated by the same privacy and category
+ * (workspace catalog) filters.
  */
 export async function findProductMetaBySlug({
   slug,
   workspace,
   user,
   client,
+  categoryids,
 }: {
   slug: Product['slug'];
   workspace: Workspace | Cloned<Workspace>;
   user?: User;
   client: Client;
+  categoryids?: (string | number)[];
 }) {
   if (!slug || !workspace) {
     return null;
@@ -746,6 +749,9 @@ export async function findProductMetaBySlug({
   return client.aOSProduct.findOne({
     where: {
       slug,
+      ...(categoryids?.length
+        ? {portalCategorySet: {id: {in: categoryids}}}
+        : {}),
       AND: [filterPrivate({user}), {OR: [{archived: false}, {archived: null}]}],
     },
     select: {

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -723,6 +723,38 @@ export async function findProductBySlug({
   }).then(({products}) => products?.[0] ?? null);
 }
 
+/**
+ * Lightweight product lookup for page metadata (title/description) only.
+ * Skips the full pricing/category pipeline of findProductBySlug — a single
+ * findOne selecting name + description, gated by the same privacy filter.
+ */
+export async function findProductMetaBySlug({
+  slug,
+  workspace,
+  user,
+  client,
+}: {
+  slug: Product['slug'];
+  workspace: Workspace | Cloned<Workspace>;
+  user?: User;
+  client: Client;
+}) {
+  if (!slug || !workspace) {
+    return null;
+  }
+
+  return client.aOSProduct.findOne({
+    where: {
+      slug,
+      AND: [filterPrivate({user}), {OR: [{archived: false}, {archived: null}]}],
+    },
+    select: {
+      name: true,
+      description: true,
+    },
+  });
+}
+
 type WSProduct = {
   productId: number;
   prices: [{type: 'WT'; price: string}, {type: 'ATI'; price: string}];

--- a/app/[tenant]/[workspace]/(subapps)/shop/layout.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/layout.tsx
@@ -41,11 +41,7 @@ export default async function Layout(props: {
 
   const config = await getShopConfig(access.workspace.config.id, client);
   const categories = config
-    ? await findCategories({
-        workspace: access.workspace,
-        client,
-        user,
-      }).then(clone)
+    ? await findCategories(access.workspace.id, user, client).then(clone)
     : [];
 
   const parentcategories = (categories as Category[])?.filter(c => !c.parent);

--- a/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
@@ -42,11 +42,9 @@ async function Categories({
   user: User | undefined;
   workspace: Workspace | Cloned<Workspace>;
 }) {
-  const categories = await findCategories({
-    workspace,
-    client,
-    user,
-  }).then(clone);
+  const categories = await findCategories(workspace.id, user, client).then(
+    clone,
+  );
 
   const parentcategories = (categories as Category[])?.filter(c => !c.parent);
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
@@ -76,8 +76,10 @@ async function Featured({
     user,
   }).then(clone)) as FeaturedCategory[];
 
-  for (const category of featuredCategories) {
-    if (category?.productList?.length) {
+  await Promise.all(
+    featuredCategories.map(async category => {
+      if (!category?.productList?.length) return;
+
       const res = await findProducts({
         ids: category.productList.map(p => p.id),
         workspace: workspace!,
@@ -89,8 +91,8 @@ async function Featured({
       }).then(clone);
 
       category.products = (res as {products: ComputedProduct[]})?.products;
-    }
-  }
+    }),
+  );
 
   const hidePriceAndPurchase = await shouldHidePricesAndPurchase({
     user,

--- a/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
@@ -54,11 +54,15 @@ export async function generateMetadata(props: {
   const {user} = access;
   const {client} = access.tenant;
 
+  const categories = await findCategories(access.workspace.id, user, client);
+  const categoryids = categories.map(c => getcategoryids(c)).flat();
+
   const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
     user,
     client,
+    categoryids,
   });
 
   if (!product) {
@@ -117,10 +121,11 @@ async function Product({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
+  const categories = await findCategories(
+    access.workspace.id,
+    user,
     client,
-  }).then(clone);
+  ).then(clone);
 
   const categoryids = categories.map(c => getcategoryids(c)).flat();
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
@@ -17,7 +17,10 @@ import {
   ProductView,
   ProductViewSkeleton,
 } from '@/subapps/shop/common/ui/components';
-import {findProductBySlug} from '@/subapps/shop/common/orm/product';
+import {
+  findProductBySlug,
+  findProductMetaBySlug,
+} from '@/subapps/shop/common/orm/product';
 import {getShopConfig} from '@/subapps/shop/common/orm/config';
 import {shouldHidePricesAndPurchase} from '@/orm/product';
 import {findCategories} from '@/subapps/shop/common/orm/categories';
@@ -50,40 +53,21 @@ export async function generateMetadata(props: {
 
   const {user} = access;
   const {client} = access.tenant;
-  const {config} = access.tenant;
 
-  const workspaceConfig = await getShopConfig(
-    access.workspace.config.id,
-    client,
-  );
-  if (!workspaceConfig) return null;
-
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-  }).then(clone);
-
-  const categoryids = categories.map(c => getcategoryids(c)).flat();
-
-  const computedProduct = await findProductBySlug({
+  const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
-    workspaceConfig,
     user,
     client,
-    config,
-    categoryids,
   });
 
-  if (!computedProduct?.product) {
+  if (!product) {
     return null;
   }
 
-  const {product} = computedProduct;
-
   return {
-    title: product?.name,
-    description: htmlToNormalString(product?.description ?? ''),
+    title: product.name,
+    description: htmlToNormalString(product.description ?? ''),
   };
 }
 

--- a/app/api/tenant/[tenant]/product/image/[id]/route.ts
+++ b/app/api/tenant/[tenant]/product/image/[id]/route.ts
@@ -61,7 +61,9 @@ export async function GET(
       return new NextResponse('File not found', {status: 404});
     }
 
-    return streamFile(file);
+    const response = await streamFile(file);
+    response.headers.set('Cache-Control', 'private, max-age=3600');
+    return response;
   } else {
     return new NextResponse('Picture not found', {status: 404});
   }

--- a/changelogs/unreleased/114538.json
+++ b/changelogs/unreleased/114538.json
@@ -1,6 +1,6 @@
 {
   "title": "Speed up shop product detail pages, home and product images",
   "type": "fix",
-  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
+  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering, scoped to the same workspace catalog as the full page. The category list used across a shop page is now fetched once per request instead of repeatedly. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
   "scope": ["shop"]
 }

--- a/changelogs/unreleased/114538.json
+++ b/changelogs/unreleased/114538.json
@@ -1,0 +1,6 @@
+{
+  "title": "Speed up shop product detail pages, home and product images",
+  "type": "fix",
+  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
+  "scope": ["shop"]
+}


### PR DESCRIPTION
https://redmine.axelor.com/issues/114538

- Product detail pages no longer run the full product pipeline twice. Page metadata now uses a lightweight title/description lookup (findProductMetaBySlug) instead of replaying findProductBySlug together with its shop-config and category queries; the full pipeline runs only once, for rendering.
- Home: featured categories are fetched in parallel instead of sequentially.
- Product image route: responses set Cache-Control: private, max-age=3600 so a given image is served from the browser cache instead of hitting the route on every scroll and navigation.

Workspace resolution is already de-duplicated per request upstream, so this change relies on it rather than re-implementing it. Access and privacy rules are unchanged.