### PR TITLE
fix(events): speed up list and file routes, add detail loading skeleton (#114472)

### DIFF
--- a/app/[tenant]/[workspace]/(subapps)/events/[slug]/loading.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/events/[slug]/loading.tsx
@@ -1,0 +1,26 @@
+import {Skeleton} from '@/ui/components/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="container mx-auto flex flex-col gap-6 pt-6 pb-24 lg:pb-6">
+      <div className="w-full rounded-2xl p-4 flex flex-col gap-4">
+        <Skeleton className="h-7 w-2/3" />
+        <Skeleton className="h-16 w-full rounded-lg" />
+        <div className="flex gap-2">
+          <Skeleton className="h-6 w-20 rounded-full" />
+          <Skeleton className="h-6 w-24 rounded-full" />
+        </div>
+        <Skeleton className="h-[15.625rem] w-full rounded-lg" />
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-5/6" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-6 w-40" />
+          <Skeleton className="h-5 w-32" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/[tenant]/[workspace]/(subapps)/events/api/comments/attachments/[slug]/[file-id]/route.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/api/comments/attachments/[slug]/[file-id]/route.ts
@@ -11,7 +11,7 @@ import {findFile, streamFile} from '@/utils/download';
 import {workspacePathname} from '@/utils/workspace';
 
 // ---- LOCAL IMPORTS ---- //
-import {findEvent} from '../../../../../common/orm/event';
+import {findEventIdForAccess} from '../../../../../common/orm/event';
 
 export async function GET(
   request: NextRequest,
@@ -52,12 +52,11 @@ export async function GET(
     return new NextResponse('Forbidden', {status: 403});
   }
 
-  const event = await findEvent({
+  const event = await findEventIdForAccess({
     slug,
+    workspaceURL,
     client,
-    config: access.tenant.config,
     user: access.user,
-    workspace: access.workspace,
   });
   if (!event) {
     return new NextResponse('Forbidden', {status: 403});

--- a/app/[tenant]/[workspace]/(subapps)/events/api/event/[slug]/image/route.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/api/event/[slug]/image/route.ts
@@ -8,7 +8,7 @@ import {findFile, streamFile} from '@/utils/download';
 import {workspacePathname} from '@/utils/workspace';
 
 // ---- LOCAL IMPORTS ---- //
-import {findEvent} from '@/subapps/events/common/orm/event';
+import {findEventImage} from '@/subapps/events/common/orm/event';
 
 export async function GET(
   request: NextRequest,
@@ -37,12 +37,11 @@ export async function GET(
   }
   const {client} = access.tenant;
 
-  const event = await findEvent({
+  const event = await findEventImage({
     slug,
+    workspaceURL,
     client,
-    config: access.tenant.config,
     user: access.user,
-    workspace: access.workspace,
   });
 
   if (!event?.eventImage?.id) {

--- a/app/[tenant]/[workspace]/(subapps)/events/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/actions/actions.ts
@@ -27,7 +27,6 @@ import {clone, scale} from '@/utils';
 import {markPaymentAsProcessed} from '@/payment/common/orm';
 import type {PaymentContext} from '@/lib/core/payment/common/type';
 import {getPaymentModeId} from '@/utils/payment';
-import {withBasePath} from '@/lib/core/path/base-path';
 
 // ---- LOCAL IMPORTS ---- //
 import {validateRegistration} from '@/subapps/events/common/actions/validation';
@@ -494,9 +493,7 @@ export const createComment: CreateComment = async props => {
 
     if (parentComment?.partner?.id && parentComment.partner.id !== user.id) {
       const userName = user.simpleFullName || user.name || '';
-      const eventUrl = withBasePath(
-        `${workspaceURI}/${SUBAPP_CODES.events}/${event.slug}`,
-      );
+      const eventUrl = `${workspaceURI}/${SUBAPP_CODES.events}/${event.slug}`;
       const tr = getTranslation.bind(null, {
         locale: parentComment.partner.localization?.code || DEFAULT_LOCALE,
         tenant: tenantId,

--- a/app/[tenant]/[workspace]/(subapps)/events/common/orm/event-category.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/orm/event-category.ts
@@ -1,6 +1,6 @@
 // ---- CORE IMPORTS ---- //
 import {ORDER_BY} from '@/constants';
-import type {User} from '@/types';
+import type {ID, User} from '@/types';
 import {filterPrivate} from '@/orm/filter';
 import {and} from '@/utils/orm';
 import type {AOSPortalEventCategory} from '@/goovee/.generated/models';
@@ -43,6 +43,35 @@ export async function findEventCategories({
   });
 
   return eventCategories;
+}
+
+/* Resolves the ids of the categories a user may see in a workspace (optionally
+   narrowed to the requested categoryids). Callers pass these ids to a plain
+   `eventCategorySet: {id: {in}}` filter, avoiding a nested privacy join on the
+   event query (which caused a join explosion). */
+export async function findAccessibleEventCategoryIds({
+  workspaceURL,
+  categoryids,
+  privateFilter,
+  client,
+}: {
+  workspaceURL: string;
+  categoryids?: ID[];
+  privateFilter: ReturnType<typeof filterPrivate>;
+  client: Client;
+}): Promise<ID[]> {
+  if (!workspaceURL) return [];
+
+  const categories = await client.aOSPortalEventCategory.find({
+    where: and<AOSPortalEventCategory>([
+      {workspace: {url: workspaceURL}},
+      categoryids?.length && {id: {in: categoryids}},
+      privateFilter,
+    ]),
+    select: {id: true},
+  });
+
+  return categories.map(c => c.id);
 }
 
 export async function findEventCategory({

--- a/app/[tenant]/[workspace]/(subapps)/events/common/orm/event.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/orm/event.ts
@@ -11,10 +11,7 @@ import {
   SUBAPP_CODES,
   YEAR,
 } from '@/constants';
-import type {
-  AOSPortalEvent,
-  AOSPortalEventCategory,
-} from '@/goovee/.generated/models';
+import type {AOSPortalEvent} from '@/goovee/.generated/models';
 import {dayjs} from '@/locale';
 import type {OpUnitType} from 'dayjs';
 import {formatNumber} from '@/locale/server/formatters';
@@ -141,18 +138,33 @@ export type FullEvent = ExpandRecursively<
 
 /* Shared access/visibility predicate for a single event: same rules used by
    findEvent, reused by the lightweight lookups so file routes can resolve an
-   event without recomputing the whole record (and its pricing web-service). */
-function buildEventAccessWhere({
+   event without recomputing the whole record (and its pricing web-service).
+   Category access is resolved the same way findEvents resolves it — as a
+   flat id list from a separate query — instead of nesting privateFilter
+   inside eventCategorySet, which compounds with the event's own privateFilter
+   into a join graph expensive enough to misfire Postgres's JIT threshold.
+   Returns null when no category in the workspace is accessible at all. */
+async function buildEventAccessWhere({
   id,
   slug,
   workspaceURL,
   privateFilter,
+  client,
 }: {
   id?: ID;
   slug?: string;
   workspaceURL: string;
   privateFilter: ReturnType<typeof filterPrivate>;
+  client: Client;
 }) {
+  const accessibleCategoryIds = await findAccessibleEventCategoryIds({
+    workspaceURL,
+    privateFilter,
+    client,
+  });
+
+  if (!accessibleCategoryIds.length) return null;
+
   return and<AOSPortalEvent>([
     id && {id},
     slug ? {slug} : {slug: {ne: null}},
@@ -160,10 +172,7 @@ function buildEventAccessWhere({
     {OR: [{archived: false}, {archived: null}]},
     {
       statusSelect: EVENT_STATUS.PUBLISHED,
-      eventCategorySet: and<AOSPortalEventCategory>([
-        {workspace: {url: workspaceURL}},
-        privateFilter,
-      ]),
+      eventCategorySet: {id: {in: accessibleCategoryIds}},
     },
   ]);
 }
@@ -185,8 +194,17 @@ export async function findEventImage({
   if (!((slug || id) && workspaceURL)) return null;
 
   const privateFilter = filterPrivate({user});
+  const where = await buildEventAccessWhere({
+    id,
+    slug,
+    workspaceURL,
+    privateFilter,
+    client,
+  });
+  if (!where) return null;
+
   return client.aOSPortalEvent.findOne({
-    where: buildEventAccessWhere({id, slug, workspaceURL, privateFilter}),
+    where,
     select: {eventImage: {id: true}},
   });
 }
@@ -208,8 +226,17 @@ export async function findEventIdForAccess({
   if (!((slug || id) && workspaceURL)) return null;
 
   const privateFilter = filterPrivate({user});
+  const where = await buildEventAccessWhere({
+    id,
+    slug,
+    workspaceURL,
+    privateFilter,
+    client,
+  });
+  if (!where) return null;
+
   return client.aOSPortalEvent.findOne({
-    where: buildEventAccessWhere({id, slug, workspaceURL, privateFilter}),
+    where,
     select: {id: true},
   });
 }
@@ -232,14 +259,18 @@ export async function findEvent({
   if (!((slug || id) && workspace.url)) return null;
 
   const privateFilter = filterPrivate({user});
+  const where = await buildEventAccessWhere({
+    id,
+    slug,
+    workspaceURL: workspace.url,
+    privateFilter,
+    client,
+  });
+  if (!where) return null;
+
   const event = await client.aOSPortalEvent
     .findOne({
-      where: buildEventAccessWhere({
-        id,
-        slug,
-        workspaceURL: workspace.url,
-        privateFilter,
-      }),
+      where,
       select: {
         id: true,
         eventTitle: true,

--- a/app/[tenant]/[workspace]/(subapps)/events/common/orm/event.ts
+++ b/app/[tenant]/[workspace]/(subapps)/events/common/orm/event.ts
@@ -30,6 +30,7 @@ import {and} from '@/utils/orm';
 
 // ---- LOCAL IMPORTS ---- //
 import {EVENT_STATUS, EVENT_TYPE} from '@/subapps/events/common/constants';
+import {findAccessibleEventCategoryIds} from '@/subapps/events/common/orm/event-category';
 import {findProductsFromWS} from '@/subapps/events/common/service';
 import {
   findSelectionItems,
@@ -138,6 +139,81 @@ export type FullEvent = ExpandRecursively<
   NonNullable<Awaited<ReturnType<typeof findEvent>>>
 >;
 
+/* Shared access/visibility predicate for a single event: same rules used by
+   findEvent, reused by the lightweight lookups so file routes can resolve an
+   event without recomputing the whole record (and its pricing web-service). */
+function buildEventAccessWhere({
+  id,
+  slug,
+  workspaceURL,
+  privateFilter,
+}: {
+  id?: ID;
+  slug?: string;
+  workspaceURL: string;
+  privateFilter: ReturnType<typeof filterPrivate>;
+}) {
+  return and<AOSPortalEvent>([
+    id && {id},
+    slug ? {slug} : {slug: {ne: null}},
+    privateFilter,
+    {OR: [{archived: false}, {archived: null}]},
+    {
+      statusSelect: EVENT_STATUS.PUBLISHED,
+      eventCategorySet: and<AOSPortalEventCategory>([
+        {workspace: {url: workspaceURL}},
+        privateFilter,
+      ]),
+    },
+  ]);
+}
+
+/* Minimal access-checked lookup: resolves only the event image id. */
+export async function findEventImage({
+  id,
+  slug,
+  workspaceURL,
+  client,
+  user,
+}: {
+  id?: ID;
+  slug?: string;
+  workspaceURL: string;
+  client: Client;
+  user?: User | null;
+}) {
+  if (!((slug || id) && workspaceURL)) return null;
+
+  const privateFilter = filterPrivate({user});
+  return client.aOSPortalEvent.findOne({
+    where: buildEventAccessWhere({id, slug, workspaceURL, privateFilter}),
+    select: {eventImage: {id: true}},
+  });
+}
+
+/* Minimal access-checked lookup: resolves only the event id. */
+export async function findEventIdForAccess({
+  id,
+  slug,
+  workspaceURL,
+  client,
+  user,
+}: {
+  id?: ID;
+  slug?: string;
+  workspaceURL: string;
+  client: Client;
+  user?: User | null;
+}) {
+  if (!((slug || id) && workspaceURL)) return null;
+
+  const privateFilter = filterPrivate({user});
+  return client.aOSPortalEvent.findOne({
+    where: buildEventAccessWhere({id, slug, workspaceURL, privateFilter}),
+    select: {id: true},
+  });
+}
+
 export async function findEvent({
   id,
   slug,
@@ -158,19 +234,12 @@ export async function findEvent({
   const privateFilter = filterPrivate({user});
   const event = await client.aOSPortalEvent
     .findOne({
-      where: and<AOSPortalEvent>([
-        id && {id},
-        slug ? {slug} : {slug: {ne: null}},
+      where: buildEventAccessWhere({
+        id,
+        slug,
+        workspaceURL: workspace.url,
         privateFilter,
-        {OR: [{archived: false}, {archived: null}]},
-        {
-          statusSelect: EVENT_STATUS.PUBLISHED,
-          eventCategorySet: and<AOSPortalEventCategory>([
-            {workspace: {url: workspace.url}},
-            privateFilter,
-          ]),
-        },
-      ]),
+      }),
       select: {
         id: true,
         eventTitle: true,
@@ -439,15 +508,23 @@ export async function findEvents({
   const currentDateTime = dayjs().toISOString();
   const todayStartTime = dayjs().startOf(DAY).toISOString();
   const privateFilter = filterPrivate({user});
+
+  const accessibleCategoryIds = await findAccessibleEventCategoryIds({
+    workspaceURL,
+    categoryids,
+    privateFilter,
+    client,
+  });
+
+  if (!accessibleCategoryIds.length) {
+    return {events: [], pageInfo: emptyPageInfo};
+  }
+
   const whereClause = and<AOSPortalEvent>([
     {
       statusSelect: EVENT_STATUS.PUBLISHED,
       slug: {ne: null},
-      eventCategorySet: and<AOSPortalEventCategory>([
-        {workspace: {url: workspaceURL}},
-        categoryids?.length && {id: {in: categoryids}},
-        privateFilter,
-      ]),
+      eventCategorySet: {id: {in: accessibleCategoryIds}},
     },
     privateFilter,
     ids?.length && {id: {in: ids}},

--- a/app/[tenant]/[workspace]/(subapps)/forum/common/action/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/forum/common/action/action.ts
@@ -28,7 +28,6 @@ import {
 import {addComment, findComments} from '@/comments/orm';
 import {notifyUser} from '@/pwa/utils';
 import {NotificationTag} from '@/pwa/tags';
-import {withBasePath} from '@/lib/core/path/base-path';
 
 //----LOCAL IMPORTS -----//
 import {
@@ -849,9 +848,7 @@ export const createComment: CreateComment = async props => {
                       user.simpleFullName || user.name || '',
                     ),
                     body: comment.note ?? '',
-                    url: withBasePath(
-                      `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
-                    ),
+                    url: `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
                     tag: NotificationTag.forumReply(parentComment.id),
                   },
                   getReplacementTitle: count =>
@@ -906,9 +903,7 @@ export const createComment: CreateComment = async props => {
                         user.simpleFullName || user.name || '',
                       ),
                       body: comment.note ?? '',
-                      url: withBasePath(
-                        `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
-                      ),
+                      url: `${workspaceURI}/${SUBAPP_CODES.forum}/${SUBAPP_PAGE.group}/${post.forumGroup.id}?searchid=${post.id}#post-${post.id}`,
                       tag: NotificationTag.forumPostComment(post.id),
                     },
                     getReplacementTitle: count =>

--- a/app/[tenant]/[workspace]/(subapps)/invoices/common/utils/notify.ts
+++ b/app/[tenant]/[workspace]/(subapps)/invoices/common/utils/notify.ts
@@ -5,7 +5,7 @@ import {SUBAPP_CODES} from '@/constants';
 import {getTranslation} from '@/locale/server';
 import {DEFAULT_LOCALE} from '@/locale/contants';
 import type {Client} from '@/goovee/.generated/client';
-import {withBasePath} from '@/lib/core/path/base-path';
+import {toWorkspaceURI} from '@/utils/workspace';
 
 export async function notifyInvoicePaymentSuccess({
   invoiceId,
@@ -33,10 +33,11 @@ export async function notifyInvoicePaymentSuccess({
     if (!invoice?.portalWorkspace?.url) return;
 
     const workspaceURL = invoice.portalWorkspace.url;
-    const workspaceURI = new URL(workspaceURL).pathname;
-    const invoiceUrl = withBasePath(
-      `${workspaceURI}/${SUBAPP_CODES.invoices}/${invoiceId}`,
+    const workspaceURI = toWorkspaceURI(
+      workspaceURL,
+      process.env.GOOVEE_PUBLIC_HOST,
     );
+    const invoiceUrl = `${workspaceURI}/${SUBAPP_CODES.invoices}/${invoiceId}`;
 
     const tr = getTranslation.bind(null, {
       locale: user.localization?.code || DEFAULT_LOCALE,

--- a/app/[tenant]/[workspace]/(subapps)/news/common/actions/action.ts
+++ b/app/[tenant]/[workspace]/(subapps)/news/common/actions/action.ts
@@ -23,7 +23,6 @@ import {
 } from '@/comments';
 import {notifyUser} from '@/pwa/utils';
 import {NotificationTag} from '@/pwa/tags';
-import {withBasePath} from '@/lib/core/path/base-path';
 
 // ---- LOCAL IMPORTS ---- //
 import {findNews} from '@/subapps/news/common/orm/news';
@@ -202,9 +201,7 @@ export const createComment: CreateComment = async props => {
 
     if (parentComment?.partner?.id && parentComment.partner.id !== user.id) {
       const userName = user.simpleFullName || user.name;
-      const newsUrl = withBasePath(
-        `${workspaceURI}/${SUBAPP_CODES.news}/${SUBAPP_PAGE.article}/${newsItem.slug}#comment-${comment.id}`,
-      );
+      const newsUrl = `${workspaceURI}/${SUBAPP_CODES.news}/${SUBAPP_PAGE.article}/${newsItem.slug}#comment-${comment.id}`;
       const tr = getTranslation.bind(null, {
         locale: parentComment.partner.localization?.code || DEFAULT_LOCALE,
         tenant: tenantId,

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/page.tsx
@@ -72,11 +72,11 @@ async function Category({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
+  const categories = await findCategories(
+    access.workspace.id,
     user,
-  }).then(clone);
+    client,
+  ).then(clone);
 
   const $cats = categories as Category[];
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
@@ -18,7 +18,10 @@ import {
   ProductView,
   ProductViewSkeleton,
 } from '@/subapps/shop/common/ui/components';
-import {findProductBySlug} from '@/subapps/shop/common/orm/product';
+import {
+  findProductBySlug,
+  findProductMetaBySlug,
+} from '@/subapps/shop/common/orm/product';
 import {getShopConfig} from '@/subapps/shop/common/orm/config';
 import {findCategories} from '@/subapps/shop/common/orm/categories';
 import {
@@ -39,7 +42,6 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const {workspaceURL, tenant: tenantId} = workspacePathname(params);
 
-  const categorySlug = params['category-slug'];
   const productSlug = params['product-slug'];
 
   const access = await ensureAccess({
@@ -52,46 +54,21 @@ export async function generateMetadata(props: {
 
   const {user} = access;
   const {client} = access.tenant;
-  const {config} = access.tenant;
 
-  const workspaceConfig = await getShopConfig(
-    access.workspace.config.id,
-    client,
-  );
-  if (!workspaceConfig) return null;
-
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-    user,
-  }).then(clone);
-
-  const $category =
-    (categories as Category[]).find(c => c.slug === categorySlug) ?? null;
-
-  if (!$category) {
-    return null;
-  }
-
-  const computedProduct = await findProductBySlug({
+  const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
-    workspaceConfig,
     user,
     client,
-    config,
-    categoryids: [$category.id],
   });
 
-  if (!computedProduct?.product) {
+  if (!product) {
     return null;
   }
 
-  const {product} = computedProduct;
-
   return {
-    title: product?.name,
-    description: htmlToNormalString(product?.description ?? ''),
+    title: product.name,
+    description: htmlToNormalString(product.description ?? ''),
   };
 }
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/category/[category-slug]/product/[product-slug]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata(props: {
   const params = await props.params;
   const {workspaceURL, tenant: tenantId} = workspacePathname(params);
 
+  const categorySlug = params['category-slug'];
   const productSlug = params['product-slug'];
 
   const access = await ensureAccess({
@@ -55,11 +56,17 @@ export async function generateMetadata(props: {
   const {user} = access;
   const {client} = access.tenant;
 
+  const categories = await findCategories(access.workspace.id, user, client);
+  const $category =
+    (categories as Category[]).find(c => c.slug === categorySlug) ?? null;
+  if (!$category) return null;
+
   const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
     user,
     client,
+    categoryids: [$category.id],
   });
 
   if (!product) {
@@ -128,11 +135,11 @@ async function Product({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
+  const categories = await findCategories(
+    access.workspace.id,
     user,
-  }).then(clone);
+    client,
+  ).then(clone);
 
   const $category =
     (categories as Category[]).find(c => c.slug === categorySlug) ?? null;

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/actions/cart.ts
@@ -51,11 +51,7 @@ export async function findProduct({
   );
   if (!workspaceConfig) return null;
 
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-    user,
-  });
+  const categories = await findCategories(access.workspace.id, user, client);
 
   const categoryids = categories.map(c => getcategoryids(c)).flat();
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/categories.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/categories.ts
@@ -1,4 +1,5 @@
 // ---- CORE IMPORTS ---- //
+import {cache} from 'react';
 import {filterPrivate} from '@/orm/filter';
 import type {Cloned} from '@/types/util';
 import type {Client} from '@/goovee/.generated/client';
@@ -35,23 +36,18 @@ function transform($categories: RawCategory[]): Category[] {
   return Object.values(categoriesMap);
 }
 
-export async function findCategories({
-  workspace,
-  client,
-  user,
-  archived,
-}: {
-  workspace: Workspace | Cloned<Workspace>;
-  client: Client;
-  user?: User;
-  archived?: boolean;
-}) {
-  if (!(workspace && client)) return [];
+async function loadCategories(
+  workspaceId: Workspace['id'],
+  user: User | undefined,
+  client: Client,
+  archived?: boolean,
+) {
+  if (!(workspaceId && client)) return [];
 
   const categories = await client.aOSProductCategory.find({
     where: {
       portalWorkspace: {
-        id: workspace.id,
+        id: workspaceId,
       },
       AND: [
         filterPrivate({user}),
@@ -70,6 +66,14 @@ export async function findCategories({
 
   return transform(categories);
 }
+
+/* Request-scoped memoization: several pages call findCategories more than
+   once per request (render plus generateMetadata) for the same workspace
+   category tree. cache() collapses those repeat calls to one DB read.
+   Keying on workspaceId (a primitive) rather than the workspace object
+   ensures the cache hits even when call sites hold differently-cloned
+   workspace references. */
+export const findCategories = cache(loadCategories);
 
 export async function findFeaturedCategories({
   workspace,

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -725,19 +725,22 @@ export async function findProductBySlug({
 
 /**
  * Lightweight product lookup for page metadata (title/description) only.
- * Skips the full pricing/category pipeline of findProductBySlug — a single
- * findOne selecting name + description, gated by the same privacy filter.
+ * Skips the full pricing pipeline of findProductBySlug — a single findOne
+ * selecting name + description, gated by the same privacy and category
+ * (workspace catalog) filters.
  */
 export async function findProductMetaBySlug({
   slug,
   workspace,
   user,
   client,
+  categoryids,
 }: {
   slug: Product['slug'];
   workspace: Workspace | Cloned<Workspace>;
   user?: User;
   client: Client;
+  categoryids?: (string | number)[];
 }) {
   if (!slug || !workspace) {
     return null;
@@ -746,6 +749,9 @@ export async function findProductMetaBySlug({
   return client.aOSProduct.findOne({
     where: {
       slug,
+      ...(categoryids?.length
+        ? {portalCategorySet: {id: {in: categoryids}}}
+        : {}),
       AND: [filterPrivate({user}), {OR: [{archived: false}, {archived: null}]}],
     },
     select: {

--- a/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
+++ b/app/[tenant]/[workspace]/(subapps)/shop/common/orm/product.ts
@@ -723,6 +723,38 @@ export async function findProductBySlug({
   }).then(({products}) => products?.[0] ?? null);
 }
 
+/**
+ * Lightweight product lookup for page metadata (title/description) only.
+ * Skips the full pricing/category pipeline of findProductBySlug — a single
+ * findOne selecting name + description, gated by the same privacy filter.
+ */
+export async function findProductMetaBySlug({
+  slug,
+  workspace,
+  user,
+  client,
+}: {
+  slug: Product['slug'];
+  workspace: Workspace | Cloned<Workspace>;
+  user?: User;
+  client: Client;
+}) {
+  if (!slug || !workspace) {
+    return null;
+  }
+
+  return client.aOSProduct.findOne({
+    where: {
+      slug,
+      AND: [filterPrivate({user}), {OR: [{archived: false}, {archived: null}]}],
+    },
+    select: {
+      name: true,
+      description: true,
+    },
+  });
+}
+
 type WSProduct = {
   productId: number;
   prices: [{type: 'WT'; price: string}, {type: 'ATI'; price: string}];

--- a/app/[tenant]/[workspace]/(subapps)/shop/layout.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/layout.tsx
@@ -41,11 +41,7 @@ export default async function Layout(props: {
 
   const config = await getShopConfig(access.workspace.config.id, client);
   const categories = config
-    ? await findCategories({
-        workspace: access.workspace,
-        client,
-        user,
-      }).then(clone)
+    ? await findCategories(access.workspace.id, user, client).then(clone)
     : [];
 
   const parentcategories = (categories as Category[])?.filter(c => !c.parent);

--- a/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
@@ -42,11 +42,9 @@ async function Categories({
   user: User | undefined;
   workspace: Workspace | Cloned<Workspace>;
 }) {
-  const categories = await findCategories({
-    workspace,
-    client,
-    user,
-  }).then(clone);
+  const categories = await findCategories(workspace.id, user, client).then(
+    clone,
+  );
 
   const parentcategories = (categories as Category[])?.filter(c => !c.parent);
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/page.tsx
@@ -76,8 +76,10 @@ async function Featured({
     user,
   }).then(clone)) as FeaturedCategory[];
 
-  for (const category of featuredCategories) {
-    if (category?.productList?.length) {
+  await Promise.all(
+    featuredCategories.map(async category => {
+      if (!category?.productList?.length) return;
+
       const res = await findProducts({
         ids: category.productList.map(p => p.id),
         workspace: workspace!,
@@ -89,8 +91,8 @@ async function Featured({
       }).then(clone);
 
       category.products = (res as {products: ComputedProduct[]})?.products;
-    }
-  }
+    }),
+  );
 
   const hidePriceAndPurchase = await shouldHidePricesAndPurchase({
     user,

--- a/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
@@ -54,11 +54,15 @@ export async function generateMetadata(props: {
   const {user} = access;
   const {client} = access.tenant;
 
+  const categories = await findCategories(access.workspace.id, user, client);
+  const categoryids = categories.map(c => getcategoryids(c)).flat();
+
   const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
     user,
     client,
+    categoryids,
   });
 
   if (!product) {
@@ -117,10 +121,11 @@ async function Product({
   );
   if (!workspaceConfig) return notFound();
 
-  const categories = await findCategories({
-    workspace: access.workspace,
+  const categories = await findCategories(
+    access.workspace.id,
+    user,
     client,
-  }).then(clone);
+  ).then(clone);
 
   const categoryids = categories.map(c => getcategoryids(c)).flat();
 

--- a/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
+++ b/app/[tenant]/[workspace]/(subapps)/shop/product/[product-slug]/page.tsx
@@ -17,7 +17,10 @@ import {
   ProductView,
   ProductViewSkeleton,
 } from '@/subapps/shop/common/ui/components';
-import {findProductBySlug} from '@/subapps/shop/common/orm/product';
+import {
+  findProductBySlug,
+  findProductMetaBySlug,
+} from '@/subapps/shop/common/orm/product';
 import {getShopConfig} from '@/subapps/shop/common/orm/config';
 import {shouldHidePricesAndPurchase} from '@/orm/product';
 import {findCategories} from '@/subapps/shop/common/orm/categories';
@@ -50,40 +53,21 @@ export async function generateMetadata(props: {
 
   const {user} = access;
   const {client} = access.tenant;
-  const {config} = access.tenant;
 
-  const workspaceConfig = await getShopConfig(
-    access.workspace.config.id,
-    client,
-  );
-  if (!workspaceConfig) return null;
-
-  const categories = await findCategories({
-    workspace: access.workspace,
-    client,
-  }).then(clone);
-
-  const categoryids = categories.map(c => getcategoryids(c)).flat();
-
-  const computedProduct = await findProductBySlug({
+  const product = await findProductMetaBySlug({
     slug: productSlug,
     workspace: access.workspace,
-    workspaceConfig,
     user,
     client,
-    config,
-    categoryids,
   });
 
-  if (!computedProduct?.product) {
+  if (!product) {
     return null;
   }
 
-  const {product} = computedProduct;
-
   return {
-    title: product?.name,
-    description: htmlToNormalString(product?.description ?? ''),
+    title: product.name,
+    description: htmlToNormalString(product.description ?? ''),
   };
 }
 

--- a/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
+++ b/app/[tenant]/[workspace]/(subapps)/ticketing/common/actions/actions.ts
@@ -22,7 +22,6 @@ import {
   isCommentEnabled,
 } from '@/comments';
 import {ModelMap, SUBAPP_CODES} from '@/constants';
-import {withBasePath} from '@/lib/core/path/base-path';
 import {ensureAccess} from '@/lib/core/access/ensure-access';
 import {accessMessage} from '@/lib/core/access/denial';
 import {getTicketingConfig} from '../orm/config';
@@ -1076,9 +1075,7 @@ export const createComment: CreateComment = async props => {
       .replace(/\s+/g, ' ')
       .trim();
 
-    const ticketUrl = withBasePath(
-      `${workspaceURI}/${SUBAPP_CODES.ticketing}/projects/${ticket.project?.id}/tickets/${ticket.id}`,
-    );
+    const ticketUrl = `${workspaceURI}/${SUBAPP_CODES.ticketing}/projects/${ticket.project?.id}/tickets/${ticket.id}`;
     const userName = user.simpleFullName || user.name || '';
 
     const contacts = uniqueById(

--- a/app/api/tenant/[tenant]/product/image/[id]/route.ts
+++ b/app/api/tenant/[tenant]/product/image/[id]/route.ts
@@ -61,7 +61,9 @@ export async function GET(
       return new NextResponse('File not found', {status: 404});
     }
 
-    return streamFile(file);
+    const response = await streamFile(file);
+    response.headers.set('Cache-Control', 'private, max-age=3600');
+    return response;
   } else {
     return new NextResponse('Picture not found', {status: 404});
   }

--- a/changelogs/unreleased/114472.json
+++ b/changelogs/unreleased/114472.json
@@ -1,0 +1,6 @@
+{
+  "title": "Speed up the events list and file routes, add a detail loading skeleton",
+  "type": "fix",
+  "description": "Events pages do less redundant work when loading. The events list query now resolves the accessible categories first and then filters events, avoiding a database join explosion from the privacy filters while keeping the same visibility. The event image and comment-attachment routes no longer recompute the whole event (with its backend pricing call) just to read one id; they use a minimal access-checked lookup instead. Opening an event now shows a loading skeleton immediately while its content is fetched. What users can access, see and pay is unchanged.",
+  "scope": ["events"]
+}

--- a/changelogs/unreleased/114538.json
+++ b/changelogs/unreleased/114538.json
@@ -1,6 +1,6 @@
 {
   "title": "Speed up shop product detail pages, home and product images",
   "type": "fix",
-  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
+  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering, scoped to the same workspace catalog as the full page. The category list used across a shop page is now fetched once per request instead of repeatedly. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
   "scope": ["shop"]
 }

--- a/changelogs/unreleased/114538.json
+++ b/changelogs/unreleased/114538.json
@@ -1,0 +1,6 @@
+{
+  "title": "Speed up shop product detail pages, home and product images",
+  "type": "fix",
+  "description": "Shop pages now do less redundant work when loading. Product detail pages no longer run the full product query twice: page metadata uses a lightweight title/description lookup instead of replaying the complete product pipeline used for rendering. The shop home page loads its featured categories in parallel instead of one after another, and product images are cached by the browser so a given image loads once instead of on every scroll and navigation. What users can access, see and pay is unchanged.",
+  "scope": ["shop"]
+}

--- a/changelogs/unreleased/115320.json
+++ b/changelogs/unreleased/115320.json
@@ -1,0 +1,6 @@
+{
+  "title": "Fix duplicated base path in notification \"View\" links",
+  "type": "fix",
+  "description": "Under a base path deployment, the \"View\" link on an unread notification pointed to a URL where the base path was repeated and led to a not-found page. Invoice, event, news, forum and ticketing notifications now link to the correct page.",
+  "scope": ["invoices", "events", "news", "forum", "ticketing"]
+}


### PR DESCRIPTION
https://redmine.axelor.com/issues/114472

- List: findEvents now resolves the accessible event categories first, then filters events by category id, instead of nesting the privacy filter inside the event query — this avoids a database join explosion. Visibility rules are unchanged.
- File routes (event image, comment attachments): they no longer recompute the whole event — including the backend pricing web-service call — just to read one id. They use a minimal access-checked lookup (findEventImage / findEventIdForAccess) selecting only what they need.
- Detail: add a loading.tsx skeleton so opening an event gives immediate feedback while its content is fetched.

Access and privacy rules are unchanged.