### PR TITLE
fix(core): read translations for pages outside a workspace from the app (#117403)

### DIFF
--- a/app/[tenant]/[workspace]/page.tsx
+++ b/app/[tenant]/[workspace]/page.tsx
@@ -32,7 +32,7 @@ export default async function Page(props: {
   const loginURL = getLoginURL({
     callbackurl: workspaceURI,
     workspaceURI,
-    [SEARCH_PARAMS.TENANT_ID]: tenant,
+    [SEARCH_PARAMS.TENANT_ID]: tenantId,
   });
 
   if (!workspaceURL) {

--- a/app/api/locales/[code]/route.ts
+++ b/app/api/locales/[code]/route.ts
@@ -1,12 +1,14 @@
 // ---- CORE IMPORTS ---- //
 import {respondWithTranslations} from '@/locale/response';
 
+/* Translations for the pages that carry no tenant in their address — the entry
+ * page, the sign-in pages and the error pages. */
 export async function GET(
   request: Request,
-  props: {params: Promise<{tenant: string; code: string}>},
+  props: {params: Promise<{code: string}>},
 ) {
   const params = await props.params;
-  const {code, tenant} = params;
+  const {code} = params;
   // NOTE: No auth required since translations are needed for every visitor
-  return respondWithTranslations(request, code, tenant);
+  return respondWithTranslations(request, code);
 }

--- a/app/locale.tsx
+++ b/app/locale.tsx
@@ -6,15 +6,12 @@ import {authClient} from '@/lib/auth-client';
 // ---- CORE IMPORTS ---- //
 import {useAppLang} from '@/ui/hooks';
 import {i18n, l10n} from '@/locale';
-import {useEnvironment} from '@/environment';
 import {useParams} from 'next/navigation';
 
 export default function Locale({children}: {children: React.ReactNode}) {
   const [loading, setLoading] = useState<number>(0);
   const params = useParams();
   const tenant = params?.tenant;
-  const env = useEnvironment();
-  const host = env?.GOOVEE_PUBLIC_HOST;
 
   const {data: session, isPending} = authClient.useSession();
   const user = session?.user;
@@ -22,20 +19,17 @@ export default function Locale({children}: {children: React.ReactNode}) {
 
   const {dir, lang} = useAppLang({locale});
 
-  const init = useCallback(
-    async (locale?: string | null, tenant?: string, host?: string) => {
-      setLoading(l => l + 1);
-      await l10n.init(locale);
-      await i18n.load(l10n.getLocale(), tenant, host);
-      setLoading(l => l - 1);
-    },
-    [],
-  );
+  const init = useCallback(async (locale?: string | null, tenant?: string) => {
+    setLoading(l => l + 1);
+    await l10n.init(locale);
+    await i18n.load(l10n.getLocale(), tenant);
+    setLoading(l => l - 1);
+  }, []);
 
   useEffect(() => {
     if (isPending) return;
-    init(locale, tenant as string, host);
-  }, [init, isPending, locale, tenant, host]);
+    init(locale, tenant as string);
+  }, [init, isPending, locale, tenant]);
 
   useEffect(() => {
     document.documentElement.lang = lang;

--- a/changelogs/unreleased/117403.json
+++ b/changelogs/unreleased/117403.json
@@ -1,0 +1,6 @@
+{
+  "title": "Stop translations erroring on a locale that ships no file",
+  "type": "fix",
+  "description": "A visitor whose locale ships no file of its own — a browser reporting en_GB or de — made the sign-in page and the other pages outside a workspace request an address that was read as a workspace, which failed with a server error and returned a page that was then absorbed into the translations as tens of thousands of stray entries. Those pages now read their translations from the application. A locale naming a region also falls back to its language for the translations shipped with the application, which INCLUDE_LANGUAGE no longer withholds — that setting governs the translations a tenant holds.",
+  "scope": ["core"]
+}

--- a/lib/core/locale/api.ts
+++ b/lib/core/locale/api.ts
@@ -64,8 +64,12 @@ async function findGeneralTranslations(locale: string): Promise<Translations> {
 
   const lang = findLocaleLanguage(locale);
 
+  /* INCLUDE_LANGUAGE governs the translations a tenant holds, not the ones
+   * shipped with the application: a shipped file keeps a language's
+   * translations under the language alone, and the ones named for a region
+   * hold only what that region says differently. */
   const [langTranslations, localeTranslations] = await Promise.all([
-    lang !== locale && includeLanguage() ? readwritecache(lang) : {},
+    lang !== locale ? readwritecache(lang) : {},
     readwritecache(locale),
   ]);
 

--- a/lib/core/locale/i18n.ts
+++ b/lib/core/locale/i18n.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import {findLocaleLanguage, translate} from '@/locale/utils';
+import {translate} from '@/locale/utils';
 import {DEFAULT_LOCALE} from '@/locale';
 import {withBasePath} from '@/lib/core/path/base-path';
 
@@ -17,44 +17,21 @@ export const i18n = (() => {
       return {};
     }
 
-    if (tenant) {
-      try {
-        const result = await rest
-          .get(
-            `${host ?? ''}${withBasePath(`/api/tenant/${tenant}/locales/${locale}`)}`,
-          )
-          .then(result => result?.data || {})
-          .catch(() => ({}));
+    const url = tenant
+      ? `${host ?? ''}${withBasePath(`/api/tenant/${tenant}/locales/${locale}`)}`
+      : withBasePath(`/api/locales/${locale}`);
 
-        translations = {
-          ...result,
-        };
-      } catch (err) {
-        console.error(err);
-      }
-    } else {
-      const fetchLocale = async (locale: string) =>
-        rest
-          .get(withBasePath(`/locales/${locale}.json`))
-          .then(r => (r?.status === 200 && r?.data ? r.data : {}))
-          .catch(() => ({}));
+    try {
+      const result = await rest
+        .get(url)
+        .then(result => result?.data || {})
+        .catch(() => ({}));
 
-      const lang = findLocaleLanguage(locale);
-
-      await Promise.all([
-        ...(lang !== locale ? [fetchLocale(lang)] : []),
-        fetchLocale(locale),
-      ])
-        .then(([langTranslations, localeTranslations]) => {
-          translations = {
-            ...translations,
-            ...langTranslations,
-            ...localeTranslations,
-          };
-        })
-        .catch(err => {
-          console.error(err);
-        });
+      translations = {
+        ...result,
+      };
+    } catch (err) {
+      console.error(err);
     }
   }
 

--- a/lib/core/locale/i18n.ts
+++ b/lib/core/locale/i18n.ts
@@ -8,18 +8,16 @@ const rest = axios.create();
 export const i18n = (() => {
   let translations: Record<string, string> = {};
 
-  async function load(
-    locale: string = DEFAULT_LOCALE,
-    tenant?: string,
-    host?: string,
-  ) {
+  async function load(locale: string = DEFAULT_LOCALE, tenant?: string) {
     if (!locale) {
       return {};
     }
 
-    const url = tenant
-      ? `${host ?? ''}${withBasePath(`/api/tenant/${tenant}/locales/${locale}`)}`
-      : withBasePath(`/api/locales/${locale}`);
+    const url = withBasePath(
+      tenant
+        ? `/api/tenant/${tenant}/locales/${locale}`
+        : `/api/locales/${locale}`,
+    );
 
     try {
       const result = await rest

--- a/lib/core/locale/i18n.ts
+++ b/lib/core/locale/i18n.ts
@@ -5,6 +5,24 @@ import {withBasePath} from '@/lib/core/path/base-path';
 
 const rest = axios.create();
 
+/* A failed request is refused by its status, but something between the browser
+ * and the application — a captive portal, a proxy that does not route the
+ * application's own addresses — can answer with a page of its own and call it
+ * success. That arrives as one long string, which spreading would key by
+ * character position. Anything that is not an object of text values is read as
+ * no translations at all. */
+function asTranslations(data: unknown): Record<string, string> {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(data).filter(
+      (entry): entry is [string, string] => typeof entry[1] === 'string',
+    ),
+  );
+}
+
 export const i18n = (() => {
   let translations: Record<string, string> = {};
 
@@ -19,18 +37,10 @@ export const i18n = (() => {
         : `/api/locales/${locale}`,
     );
 
-    try {
-      const result = await rest
-        .get(url)
-        .then(result => result?.data || {})
-        .catch(() => ({}));
-
-      translations = {
-        ...result,
-      };
-    } catch (err) {
-      console.error(err);
-    }
+    translations = await rest
+      .get(url)
+      .then(result => asTranslations(result?.data))
+      .catch(() => ({}));
   }
 
   function t(text: string, ...interpolations: string[]) {

--- a/lib/core/locale/response.ts
+++ b/lib/core/locale/response.ts
@@ -1,0 +1,37 @@
+import {NextResponse} from 'next/server';
+
+// ---- CORE IMPORTS ---- //
+import {findTranslations} from '@/locale/api';
+
+export async function respondWithTranslations(
+  request: Request,
+  locale: string,
+  tenantId?: string,
+) {
+  try {
+    const {translations, hash} = await findTranslations(locale, tenantId);
+    const etag = `"${hash}"`;
+
+    /* NOTE: Caching handled by the service worker (StaleWhileRevalidate):
+     * every load is served from cache and revalidated in the background.
+     * Cache-Control: no-cache makes the browser HTTP cache revalidate that
+     * background fetch with If-None-Match, so it costs a bodyless 304 unless
+     * translations actually changed. */
+    const headers = {ETag: etag, 'Cache-Control': 'no-cache'};
+
+    /* Proxies may turn a strong ETag into a weak one (W/"...") when they
+     * compress the response, so compare ignoring the weakness prefix. */
+    const ifNoneMatch = request.headers.get('if-none-match');
+    const matches = ifNoneMatch
+      ?.split(',')
+      .some(tag => tag.trim().replace(/^W\//, '') === etag);
+
+    if (matches) {
+      return new NextResponse(null, {status: 304, headers});
+    }
+
+    return NextResponse.json(translations, {headers});
+  } catch (err) {
+    return NextResponse.json({});
+  }
+}

--- a/lib/core/pwa/sw.ts
+++ b/lib/core/pwa/sw.ts
@@ -27,12 +27,12 @@ const serwist = new Serwist({
   navigationPreload: true,
   runtimeCaching: [
     /* Locale translations: served from cache instantly, revalidated in the
-     * background on every load. The API route sets ETag + Cache-Control:
+     * background on every load. The API routes set ETag + Cache-Control:
      * no-cache, so the background fetch is a bodyless 304 via the browser
      * HTTP cache unless translations actually changed. Must be listed before
      * defaultCache to override the default NetworkFirst rule for /api/**. */
     {
-      matcher: /\/api\/tenant\/[^/]+\/locales\//,
+      matcher: /\/api\/(tenant\/[^/]+\/)?locales\//,
       handler: new StaleWhileRevalidate({
         cacheName: 'locale-translations',
       }),


### PR DESCRIPTION
Same change as [#198](https://github.com/axelor/goovee/pull/198), for the 1.8.3 line.

https://redmine.axelor.com/issues/117403

The sign-in page and the other pages outside a workspace read their translations
from a file served under the public directory. Files ship for a few locales only,
so any other locale — `en_GB`, `de`, `es` — matched no file, fell through to the
App Router as a workspace address, and failed with `Error getting tenant` three
times per request. That failure answered with a page, which was then accepted as
a set of translations: 31,218 entries, one per character.

Those pages now read their translations from the application.

Along the way, two things that path depended on:

- `INCLUDE_LANGUAGE` was withholding the translations shipped with the
  application. A file named for a region holds only its own differences and is
  otherwise empty, so a locale such as `fr_FR` was left with nothing. That
  setting governs the translations a tenant holds; the shipped files always fall
  back to the language.
- Translations were requested from `GOOVEE_PUBLIC_HOST` rather than the address
  the browser is on. Where the two differ the request is refused for coming from
  another origin, silently. Both requests are now relative, which also makes the
  service worker cache the tenant bundle reliably.

Verified against a running instance, with the setting on and off:

| | `INCLUDE_LANGUAGE=true` | unset / `false` |
|---|---|---|
| `/api/locales/en_GB` | 1906 keys | 1906 keys |
| `/api/locales/fr_FR` | 1906 keys | 1906 keys |
| `/api/locales/de` | 0 keys | 0 keys |
| `/api/tenant/d/locales/fr_FR` | 18768 keys | 1906 keys |

The last row is the setting still doing its job: the tenant's own `fr` rows are
withheld when it is off, while the shipped `fr` file is not.
